### PR TITLE
refactor: separate model/ui state from ViewModel files

### DIFF
--- a/app/src/main/java/com/drs/auralife/presentation/auth/AuthUiState.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/auth/AuthUiState.kt
@@ -1,0 +1,8 @@
+package com.drs.auralife.presentation.auth
+
+sealed class AuthUiState {
+    data object Idle : AuthUiState()
+    data object Loading : AuthUiState()
+    data class Success(val message: String) : AuthUiState()
+    data class Error(val message: String) : AuthUiState()
+}

--- a/app/src/main/java/com/drs/auralife/presentation/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/auth/AuthViewModel.kt
@@ -12,13 +12,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-sealed class AuthUiState {
-    data object Idle : AuthUiState()
-    data object Loading : AuthUiState()
-    data class Success(val message: String) : AuthUiState()
-    data class Error(val message: String) : AuthUiState()
-}
-
 @HiltViewModel
 class AuthViewModel @Inject constructor(
     private val loginUseCase: LoginUseCase,

--- a/app/src/main/java/com/drs/auralife/presentation/home/HomeFilmsData.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/home/HomeFilmsData.kt
@@ -1,0 +1,8 @@
+package com.drs.auralife.presentation.home
+
+import com.drs.auralife.domain.model.Film
+
+data class HomeFilmsData(
+    val films: List<Film>,
+    val totalPages: Int,
+)

--- a/app/src/main/java/com/drs/auralife/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/home/HomeViewModel.kt
@@ -2,7 +2,6 @@ package com.drs.auralife.presentation.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.drs.auralife.domain.model.Film
 import com.drs.auralife.domain.usecase.GetBannersUseCase
 import com.drs.auralife.domain.usecase.GetLatestFilmsUseCase
 import com.drs.auralife.presentation.UiState
@@ -12,11 +11,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
-data class HomeFilmsData(
-    val films: List<Film>,
-    val totalPages: Int,
-)
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(


### PR DESCRIPTION
### Changes
- Extract \AuthUiState\ from \AuthViewModel.kt\ → \AuthUiState.kt\
- Extract \HomeFilmsData\ from \HomeViewModel.kt\ → \HomeFilmsData.kt\

Both types remain in the same package so no import changes needed in consumers.

Part of Phase 4.1 in PLAN_UI_CLEANUP.md