### PR TITLE
refactor: Extract search logic from MainActivity into SearchController

### DIFF
--- a/app/src/main/java/com/drs/auralife/presentation/MainActivity.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/MainActivity.kt
@@ -5,10 +5,6 @@ import android.content.Intent
 import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
-import android.text.Editable
-import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.EditText
@@ -27,7 +23,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.utils.widget.ImageFilterButton
 import androidx.constraintlayout.utils.widget.ImageFilterView
 import androidx.core.content.edit
-import androidx.core.view.get
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -47,8 +42,7 @@ import com.drs.auralife.core.utils.UpdateLibraryWorker
 import com.drs.auralife.presentation.auth.LoginActivity
 import com.drs.auralife.presentation.auth.AuthViewModel
 import com.drs.auralife.presentation.common.NotificationAdapter
-import com.drs.auralife.presentation.search.SearchFilmAdapter
-import com.drs.auralife.presentation.search.SearchViewModel
+import com.drs.auralife.presentation.search.SearchController
 import com.drs.auralife.presentation.explore.ExploreFragment
 import com.drs.auralife.presentation.filmdetails.FilmDetailsActivity
 import com.drs.auralife.presentation.filmdetails.EXTRA_SLUG
@@ -59,24 +53,23 @@ import com.drs.auralife.presentation.payment.PaymentActivity
 import com.drs.auralife.presentation.start.ViewPagerAdapter
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.navigation.NavigationView
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.util.concurrent.TimeUnit
 
 @dagger.hilt.android.AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
-    private val searchBar: EditText by lazy { findViewById(R.id.search_bar) }
-    private val searchLayout: LinearLayout by lazy { findViewById(R.id.search_layout) }
-    private val searchResults: RecyclerView by lazy { findViewById(R.id.search_results) }
+    companion object {
+        private const val PREF_NAME = "PREFERENCE"
+    }
     private val viewPager: ViewPager2 by lazy { findViewById(R.id.view_pager) }
     private val drawerLayout: DrawerLayout by lazy { findViewById(R.id.main_layout) }
     private val navigationView: NavigationView by lazy { findViewById(R.id.navigation_view) }
     private val bottomNavigationView: BottomNavigationView by lazy { findViewById(R.id.bottom_navigation_view) }
     private var permissionPhotoHandler: PermissionPhotoHandler? = null
-    private var searchIsVisible = false
-    private val filmAdapter = SearchFilmAdapter(mutableListOf())
-    private val searchHandler = Handler(Looper.getMainLooper())
-    private var searchRunnable: Runnable? = null
+    private var searchController: SearchController? = null
+
+    private val authViewModel: AuthViewModel by viewModels()
+    private val mainViewModel: MainViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -85,7 +78,7 @@ class MainActivity : AppCompatActivity() {
         setupDrawer()
         setupBackPressed()
         setupViewPager()
-        setupSearchBar()
+        initSearchController()
     }
 
     override fun onRequestPermissionsResult(
@@ -136,7 +129,7 @@ class MainActivity : AppCompatActivity() {
         val navEmail = navigationHeader.findViewById<TextView>(R.id.navEmail)
         val navPic = navigationHeader.findViewById<ImageView>(R.id.navProfilePic)
         val navPremiumStatus = navigationHeader.findViewById<TextView>(R.id.navPremiumStatus)
-        val sharedPreferences = getSharedPreferences("PREFERENCE", MODE_PRIVATE)
+        val sharedPreferences = getSharedPreferences(PREF_NAME, MODE_PRIVATE)
 
         observePremiumStatus(navPremiumStatus, sharedPreferences)
         observeAvatarResult()
@@ -250,16 +243,10 @@ class MainActivity : AppCompatActivity() {
     private fun setupBackPressed() {
         val onBackPressedCallback = object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
-                if (searchIsVisible) {
-                    searchLayout.visibility = View.GONE
-                    bottomNavigationView.visibility = View.VISIBLE
-                    viewPager.visibility = View.VISIBLE
-                    searchIsVisible = false
-                    filmAdapter.clearItems()
-                    searchBar.text.clear()
-                } else {
-                    finish()
+                if (searchController?.handleBackPress() == true) {
+                    return
                 }
+                finish()
             }
         }
 
@@ -295,59 +282,24 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private val searchViewModel: SearchViewModel by viewModels()
-    private val authViewModel: AuthViewModel by viewModels()
-    private val mainViewModel: MainViewModel by viewModels()
-
-    private fun setupSearchBar() {
-        searchResults.layoutManager = LinearLayoutManager(this)
-        searchResults.adapter = filmAdapter
-
-        observeSearchResults()
-
-        searchBar.addTextChangedListener(
-            object : TextWatcher {
-                override fun beforeTextChanged(
-                    p0: CharSequence?,
-                    p1: Int,
-                    p2: Int,
-                    p3: Int,
-                ) {
-                }
-
-                override fun onTextChanged(
-                    p0: CharSequence?,
-                    p1: Int,
-                    p2: Int,
-                    p3: Int,
-                ) {
-                }
-
-                override fun afterTextChanged(s: Editable?) {
-                    searchRunnable?.let { searchHandler.removeCallbacks(it) }
-                    val query = s.toString().trim()
-                    if (query.isEmpty()) {
-                        filmAdapter.clearItems()
-                    } else {
-                        val runnable = Runnable {
-                            searchViewModel.searchFilms(query, 5)
-                        }
-                        searchRunnable = runnable
-                        searchHandler.postDelayed(runnable, 500)
-                    }
-                }
-            },
+    private fun initSearchController() {
+        val searchBar = findViewById<EditText>(R.id.search_bar)
+        val searchLayout = findViewById<LinearLayout>(R.id.search_layout)
+        val searchResults = findViewById<RecyclerView>(R.id.search_results)
+        searchController = SearchController(
+            activity = this,
+            searchBar = searchBar,
+            searchLayout = searchLayout,
+            searchResults = searchResults,
+            contentContainer = viewPager,
+            bottomNav = bottomNavigationView,
         )
+        searchController?.setup()
     }
 
-    private fun observeSearchResults() {
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                searchViewModel.searchResultsState.collect { results ->
-                    filmAdapter.replaceItems(results)
-                }
-            }
-        }
+    override fun onDestroy() {
+        searchController?.destroy()
+        super.onDestroy()
     }
 
     @SuppressLint("InflateParams")
@@ -378,11 +330,7 @@ class MainActivity : AppCompatActivity() {
         }
 
         appBarSearch.setOnClickListener {
-            searchLayout.visibility = View.VISIBLE
-            bottomNavigationView.visibility = View.GONE
-            viewPager.visibility = View.GONE
-            searchBar.requestFocus()
-            searchIsVisible = true
+            searchController?.showSearch()
         }
 
         appBarNotifications.setOnClickListener {

--- a/app/src/main/java/com/drs/auralife/presentation/search/SearchController.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/search/SearchController.kt
@@ -1,0 +1,112 @@
+package com.drs.auralife.presentation.search
+
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.View
+import android.widget.EditText
+import android.widget.LinearLayout
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.launch
+
+@OptIn(FlowPreview::class)
+class SearchController(
+    private val activity: AppCompatActivity,
+    private val searchBar: EditText,
+    private val searchLayout: LinearLayout,
+    private val searchResults: RecyclerView,
+    private val contentContainer: View,
+    private val bottomNav: View,
+) {
+    private val searchViewModel: SearchViewModel by activity.viewModels()
+    private val filmAdapter = SearchFilmAdapter(mutableListOf())
+    private val queryFlow = MutableStateFlow("")
+    private var searchIsVisible = false
+
+    fun setup() {
+        searchResults.layoutManager = LinearLayoutManager(activity)
+        searchResults.adapter = filmAdapter
+        observeSearchResults()
+        setupQueryDebounce()
+        setupTextWatcher()
+    }
+
+    fun handleBackPress(): Boolean {
+        if (searchIsVisible) {
+            hideSearch()
+            return true
+        }
+        return false
+    }
+
+    fun showSearch() {
+        searchLayout.visibility = View.VISIBLE
+        contentContainer.visibility = View.GONE
+        bottomNav.visibility = View.GONE
+        searchBar.requestFocus()
+        searchIsVisible = true
+    }
+
+    fun destroy() {
+        // no-op: coroutines cancel with lifecycle
+    }
+
+    private fun hideSearch() {
+        searchLayout.visibility = View.GONE
+        contentContainer.visibility = View.VISIBLE
+        bottomNav.visibility = View.VISIBLE
+        searchIsVisible = false
+        filmAdapter.replaceItems(emptyList())
+        searchBar.text.clear()
+        queryFlow.value = ""
+    }
+
+    private fun observeSearchResults() {
+        activity.lifecycleScope.launch {
+            activity.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                searchViewModel.searchResultsState.collect { results ->
+                    filmAdapter.replaceItems(results)
+                }
+            }
+        }
+    }
+
+    private fun setupQueryDebounce() {
+        activity.lifecycleScope.launch {
+            activity.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                queryFlow
+                    .debounce(500)
+                    .distinctUntilChanged()
+                    .filter { it.isNotEmpty() }
+                    .collectLatest { query ->
+                        searchViewModel.searchFilms(query, 5)
+                    }
+            }
+        }
+    }
+
+    private fun setupTextWatcher() {
+        searchBar.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+            override fun afterTextChanged(s: Editable?) {
+                val query = s.toString().trim()
+                queryFlow.value = query
+                if (query.isEmpty()) {
+                    filmAdapter.replaceItems(emptyList())
+                }
+            }
+        })
+    }
+}


### PR DESCRIPTION
## Changes
- Created `SearchController` class in `search/` package to encapsulate all search UI logic
- MainActivity now delegates search lifecycle to `SearchController` (show, hide, back-press)
- Replaced `Handler`+`Runnable` debounce with coroutine `Flow.debounce()` (lifecycle-aware via `repeatOnLifecycle`)
- Moved `authViewModel`/`mainViewModel` declarations to top of class (before `onCreate`)
- Extracted hardcoded `"PREFERENCE"` string as `PREF_NAME` constant
- Removed ~81 lines of search responsibilities from MainActivity

## Benefits
- Search is now a self-contained concern -- easy to test, modify, or replace
- No more `Handler` memory leak in legacy search code
- Debounce respects fragment lifecycle via `repeatOnLifecycle(STARTED)`
