### PR TITLE
fix: Move WorkManager scheduling out of authState collect block

### DIFF
--- a/app/src/main/java/com/drs/auralife/presentation/MainActivity.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/MainActivity.kt
@@ -151,19 +151,6 @@ class MainActivity : AppCompatActivity() {
                         mainViewModel.loadAvatar()
                         navPremiumStatus.visibility = View.VISIBLE
                         mainViewModel.loadPremiumStatus()
-
-                        WorkManager.getInstance(this@MainActivity).enqueueUniquePeriodicWork(
-                            "UpdateEpisodeWork",
-                            ExistingPeriodicWorkPolicy.KEEP,
-                            PeriodicWorkRequestBuilder<UpdateLibraryWorker>(
-                                6,
-                                TimeUnit.HOURS,
-                            ).build(),
-                        )
-
-                        WorkManager
-                            .getInstance(this@MainActivity)
-                            .enqueue(OneTimeWorkRequestBuilder<UpdateLibraryWorker>().build())
                     } else {
                         navLogin.isVisible = true
                         navLogout.isVisible = false
@@ -173,6 +160,24 @@ class MainActivity : AppCompatActivity() {
                         sharedPreferences.edit { putString("ExpireDate", "") }
                     }
                 }
+            }
+        }
+
+        lifecycleScope.launch {
+            val isLoggedIn = mainViewModel.authState.first()
+            if (isLoggedIn) {
+                WorkManager.getInstance(this@MainActivity).enqueueUniquePeriodicWork(
+                    "UpdateEpisodeWork",
+                    ExistingPeriodicWorkPolicy.KEEP,
+                    PeriodicWorkRequestBuilder<UpdateLibraryWorker>(
+                        6,
+                        TimeUnit.HOURS,
+                    ).build(),
+                )
+
+                WorkManager
+                    .getInstance(this@MainActivity)
+                    .enqueue(OneTimeWorkRequestBuilder<UpdateLibraryWorker>().build())
             }
         }
 


### PR DESCRIPTION
WorkManager scheduling was inside a \epeatOnLifecycle(STARTED)\ + \collect\ block

- Separated WorkManager scheduling into one-shot lifecycleScope.launch using authState.first() for a single login check
- collect block now only handles UI updates (visibility, text, avatar)