### PR TITLE
fix: Room relation, Firebase mapping, grid overflow, and naming bugs

### DIFF
--- a/app/src/main/java/com/drs/auralife/data/local/entity/LibraryFilmCrossRef.kt
+++ b/app/src/main/java/com/drs/auralife/data/local/entity/LibraryFilmCrossRef.kt
@@ -5,6 +5,7 @@ import androidx.room.Entity
 @Entity(
     tableName = "library_film_cross_ref",
     primaryKeys = ["libraryName", "filmSlug"],
+    indices = [androidx.room.Index("filmSlug")],
 )
 data class LibraryFilmCrossRef(
     val libraryName: String,

--- a/app/src/main/java/com/drs/auralife/data/local/entity/LibraryWithFilms.kt
+++ b/app/src/main/java/com/drs/auralife/data/local/entity/LibraryWithFilms.kt
@@ -4,15 +4,15 @@ import androidx.room.Embedded
 import androidx.room.Relation
 
 data class LibraryWithFilms(
-    @Embedded val library: LibraryEntity,
+    @Embedded var library: LibraryEntity,
     @Relation(
         parentColumn = "name",
-        entityColumn = "filmSlug",
+        entityColumn = "slug",
         associateBy = androidx.room.Junction(
             LibraryFilmCrossRef::class,
             parentColumn = "libraryName",
             entityColumn = "filmSlug",
         ),
     )
-    val films: List<FilmEntity>,
+    var films: List<FilmEntity>,
 )

--- a/app/src/main/java/com/drs/auralife/data/repository/HistoryRepositoryImpl.kt
+++ b/app/src/main/java/com/drs/auralife/data/repository/HistoryRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.drs.auralife.data.repository
 import com.drs.auralife.data.local.dao.HistoryDao
 import com.drs.auralife.data.local.mapper.LocalMapper.toDomainHistoryItem
 import com.drs.auralife.data.local.mapper.LocalMapper.toHistoryEntity
+import com.drs.auralife.data.remote.firebase.FirebaseMapper.toDomainHistoryItem
 import com.drs.auralife.data.remote.firebase.HistoryDataSource
 import com.drs.auralife.domain.model.HistoryItem
 import com.drs.auralife.domain.repository.HistoryRepository

--- a/app/src/main/java/com/drs/auralife/data/repository/LibraryRepositoryImpl.kt
+++ b/app/src/main/java/com/drs/auralife/data/repository/LibraryRepositoryImpl.kt
@@ -6,9 +6,17 @@ import com.drs.auralife.data.local.mapper.LocalMapper.toDomainLibrary
 import com.drs.auralife.data.local.mapper.LocalMapper.toLibraryEntity
 import com.drs.auralife.data.local.mapper.LocalMapper.toLibraryFilmCrossRefs
 import com.drs.auralife.data.remote.firebase.LibraryDataSource
+import com.drs.auralife.data.remote.firebase.model.library.Library as FirebaseLibrary
 import com.drs.auralife.domain.model.Library
+import com.drs.auralife.domain.model.LibraryFilm
 import com.drs.auralife.domain.repository.LibraryRepository
 import javax.inject.Inject
+
+private fun FirebaseLibrary.toDomainLibrary(): Library = Library(
+    name = name,
+    posterUrl = posterUrl,
+    films = listFilm.map { LibraryFilm(slug = it.slug, currentEpisode = it.episode) },
+)
 
 class LibraryRepositoryImpl @Inject constructor(
     private val libraryDao: LibraryDao,
@@ -16,7 +24,7 @@ class LibraryRepositoryImpl @Inject constructor(
 ) : LibraryRepository {
     override suspend fun getLibraries(): List<Library> {
         return try {
-            val libraries = LibraryDataSource.getLibrary()
+            val libraries = LibraryDataSource.getLibrary().map { it.toDomainLibrary() }
             libraryDao.clear()
             libraryFilmCrossRefDao.clear()
             libraries.forEach { lib ->
@@ -31,7 +39,7 @@ class LibraryRepositoryImpl @Inject constructor(
 
     override suspend fun getLibrary(name: String): Library? {
         return try {
-            val library = LibraryDataSource.getLibraryData(name)
+            val library = LibraryDataSource.getLibraryData(name)?.toDomainLibrary()
             if (library != null) {
                 libraryDao.insertLibrary(library.toLibraryEntity())
                 libraryFilmCrossRefDao.insertAll(library.toLibraryFilmCrossRefs())

--- a/app/src/main/java/com/drs/auralife/presentation/MainActivity.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/MainActivity.kt
@@ -53,8 +53,10 @@ import com.drs.auralife.presentation.payment.PaymentActivity
 import com.drs.auralife.presentation.start.ViewPagerAdapter
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.navigation.NavigationView
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.util.concurrent.TimeUnit
+import androidx.core.view.get
 
 @dagger.hilt.android.AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
@@ -133,7 +135,7 @@ class MainActivity : AppCompatActivity() {
         val navigationHeader = navigationView.getHeaderView(0)
         val navEmail = navigationHeader.findViewById<TextView>(R.id.navEmail)
         val navPic = navigationHeader.findViewById<ImageView>(R.id.navProfilePic)
-        val navPremiumStatus = navigationHeader.findViewById<TextView>(R.id.navPremiumStatus)
+        val navPremiumStatus = navigationHeader.findViewById<TextView>(R.id.navFreemium)
         val sharedPreferences = getSharedPreferences(PREF_NAME, MODE_PRIVATE)
 
         observePremiumStatus(navPremiumStatus, sharedPreferences)

--- a/app/src/main/java/com/drs/auralife/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/home/HomeFragment.kt
@@ -124,7 +124,7 @@ class HomeFragment : Fragment() {
         if (context?.isConnectedToInternet() == true) {
             binding.recyclerView.apply {
                 val displayMetrics = resources.displayMetrics
-                var numberFilmInLine = (displayMetrics.widthPixels / 180).coerceIn(2, 5)
+                var numberFilmInLine = (displayMetrics.widthPixels / 400).coerceIn(2, 5)
                 layoutManager = GridLayoutManager(requireContext(), ++numberFilmInLine)
                 adapter = filmAdapter
             }

--- a/app/src/main/java/com/drs/auralife/presentation/playfilm/PlayFilmActivity.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/playfilm/PlayFilmActivity.kt
@@ -318,6 +318,6 @@ class PlayFilmActivity : AppCompatActivity() {
         private const val REWIND_MS = 5000L
         private const val FORWARD_MS = 15000L
         private const val PLAYER_HEIGHT_DP = 250f
-        private const val FREE_PREVIEW_LIMIT_MS = 5 * 60 * 1000
+        private const val FREE_PREVIEW_LIMIT_MS = 5L * 60 * 1000
     }
 }

--- a/app/src/main/java/com/drs/auralife/presentation/search/SearchFilmAdapter.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/search/SearchFilmAdapter.kt
@@ -20,9 +20,9 @@ class SearchFilmAdapter(
     class ViewHolder(
         itemView: View,
     ) : RecyclerView.ViewHolder(itemView) {
-        val ivPoster: ImageView = itemView.findViewById(R.id.ivPoster)
-        val tvTitle: TextView = itemView.findViewById(R.id.tvTitle)
-        val tvDetails: TextView = itemView.findViewById(R.id.tvDetails)
+        val posterView: ImageView = itemView.findViewById(R.id.posterView)
+        val tvTitle: TextView = itemView.findViewById(R.id.nameFilm)
+        val tvDetails: TextView = itemView.findViewById(R.id.details)
     }
 
     override fun onCreateViewHolder(
@@ -31,7 +31,7 @@ class SearchFilmAdapter(
     ): ViewHolder {
         val view = LayoutInflater
             .from(parent.context)
-            .inflate(R.layout.item_film, parent, false)
+            .inflate(R.layout.item_film_horizontal, parent, false)
         return ViewHolder(view)
     }
 
@@ -45,7 +45,7 @@ class SearchFilmAdapter(
         MyAppGlideModule.loadImage(
             holder.itemView.context,
             film.posterUrl,
-            holder.ivPoster,
+            holder.posterView,
         )
         holder.itemView.setOnClickListener {
             val intent = Intent(holder.itemView.context, FilmDetailsActivity::class.java)


### PR DESCRIPTION
## Summary
8 file fixes for various bugs:

**Room**
- Added index on filmSlug in LibraryFilmCrossRef for query performance
- Fixed LibraryWithFilms entityColumn from filmSlug to slug (points to FilmEntity.slug, not junction)
- Changed val to var on relation fields so Room can assign them

**Firebase mapping**
- Added FirebaseLibrary.toDomainLibrary() in LibraryRepositoryImpl to map Firebase models correctly
- Fixed missing FirebaseMapper.toDomainHistoryItem import in HistoryRepositoryImpl

**UI**
- Fixed navPremiumStatus to navFreemium ID reference in MainActivity
- Adjusted HomeFragment grid column divisor 180 to 400 (fewer, correct-sized columns)
- Updated SearchFilmAdapter to use item_film_horizontal layout with correct IDs

**Overflow**
- Added L suffix to FREE_PREVIEW_LIMIT_MS in PlayFilmActivity to prevent integer overflow