### PR TITLE
refactor: Replace MainActivity cast with AppBarProvider interface

### DIFF
--- a/app/src/main/java/com/drs/auralife/presentation/AppBarProvider.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/AppBarProvider.kt
@@ -1,0 +1,7 @@
+package com.drs.auralife.presentation
+
+import android.widget.FrameLayout
+
+interface AppBarProvider {
+    fun setupAppBar(container: FrameLayout)
+}

--- a/app/src/main/java/com/drs/auralife/presentation/MainActivity.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/MainActivity.kt
@@ -59,7 +59,7 @@ import java.util.concurrent.TimeUnit
 import androidx.core.view.get
 
 @dagger.hilt.android.AndroidEntryPoint
-class MainActivity : AppCompatActivity() {
+class MainActivity : AppCompatActivity(), AppBarProvider {
     companion object {
         private const val PREF_NAME = "PREFERENCE"
     }
@@ -315,7 +315,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     @SuppressLint("InflateParams")
-    fun setupAppBar(view: FrameLayout) {
+    override fun setupAppBar(view: FrameLayout) {
         view.addView(layoutInflater.inflate(R.layout.app_bar, null), 0)
         val appBarProfile = view.findViewById<ImageFilterButton>(R.id.app_bar_profile)
         val appBarSearch = view.findViewById<ImageButton>(R.id.app_bar_search)

--- a/app/src/main/java/com/drs/auralife/presentation/explore/ExploreFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/explore/ExploreFragment.kt
@@ -11,7 +11,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
 import com.drs.auralife.R
 import com.drs.auralife.databinding.FragmentExploreBinding
-import com.drs.auralife.presentation.MainActivity
+import com.drs.auralife.presentation.AppBarProvider
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -29,7 +29,7 @@ class ExploreFragment : Fragment() {
         savedInstanceState: Bundle?,
     ): View {
         _binding = FragmentExploreBinding.inflate(inflater, container, false)
-        (requireActivity() as MainActivity).setupAppBar(binding.appBar)
+        (requireActivity() as AppBarProvider).setupAppBar(binding.appBar)
 
         exploreViewModel.loadCategories()
 

--- a/app/src/main/java/com/drs/auralife/presentation/history/HistoryFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/history/HistoryFragment.kt
@@ -10,7 +10,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.drs.auralife.R
 import com.drs.auralife.databinding.FragmentHistoryBinding
-import com.drs.auralife.presentation.MainActivity
+import com.drs.auralife.presentation.AppBarProvider
 import com.drs.auralife.presentation.common.UiState
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -30,7 +30,7 @@ class HistoryFragment :
         savedInstanceState: Bundle?,
     ): View {
         _binding = FragmentHistoryBinding.inflate(inflater, container, false)
-        (requireActivity() as MainActivity).setupAppBar(binding.appBar)
+        (requireActivity() as AppBarProvider).setupAppBar(binding.appBar)
         binding.appBar.findViewById<ImageButton>(R.id.app_bar_search).visibility = View.GONE
         filmAdapter.setCallback(this)
         return binding.root

--- a/app/src/main/java/com/drs/auralife/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/home/HomeFragment.kt
@@ -18,7 +18,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.GridLayoutManager
 import com.drs.auralife.R
 import com.drs.auralife.databinding.FragmentHomeBinding
-import com.drs.auralife.presentation.MainActivity
+import com.drs.auralife.presentation.AppBarProvider
 import com.drs.auralife.presentation.common.UiState
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
@@ -45,7 +45,7 @@ class HomeFragment : Fragment() {
         savedInstanceState: Bundle?,
     ): View {
         _binding = FragmentHomeBinding.inflate(inflater, container, false)
-        (requireActivity() as MainActivity).setupAppBar(binding.appBar)
+        (requireActivity() as AppBarProvider).setupAppBar(binding.appBar)
         return binding.root
     }
 

--- a/app/src/main/java/com/drs/auralife/presentation/library/LibraryFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/library/LibraryFragment.kt
@@ -12,7 +12,7 @@ import androidx.lifecycle.lifecycleScope
 import com.drs.auralife.R
 import com.drs.auralife.databinding.FragmentLibraryBinding
 import com.drs.auralife.domain.repository.AuthRepository
-import com.drs.auralife.presentation.MainActivity
+import com.drs.auralife.presentation.AppBarProvider
 import com.drs.auralife.presentation.common.UiState
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -34,7 +34,7 @@ class LibraryFragment : Fragment() {
         savedInstanceState: Bundle?,
     ): View {
         _binding = FragmentLibraryBinding.inflate(inflater, container, false)
-        (requireActivity() as MainActivity).setupAppBar(binding.appBar)
+        (requireActivity() as AppBarProvider).setupAppBar(binding.appBar)
         binding.appBar.findViewById<ImageButton>(R.id.app_bar_search).visibility = View.GONE
         binding.appBar.findViewById<ImageButton>(R.id.app_bar_notifications).visibility = View.VISIBLE
         return binding.root


### PR DESCRIPTION
## Problem
4 fragments cast to requireActivity() as MainActivity to call setupAppBar(), creating tight coupling.

## Solution
- Created AppBarProvider interface with fun setupAppBar(container: FrameLayout)
- MainActivity implements AppBarProvider
- All 4 fragments (Home, Explore, Library, History) now cast to AppBarProvider instead of concrete MainActivity

## Benefits
- Fragments no longer depend on concrete Activity class
- Easier to test, swap Activity, or provide alternative app bar implementations