### PR TITLE
refactor: Convert UpdateLibraryWorker to HiltWorker with HiltWorkerFactory

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,6 +90,7 @@ dependencies {
     // --- Hilt ---
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
+    implementation(libs.hilt.work)
 
     // --- Room ---
     implementation(libs.room.runtime)

--- a/app/src/main/java/com/drs/auralife/AuraLifeApplication.kt
+++ b/app/src/main/java/com/drs/auralife/AuraLifeApplication.kt
@@ -1,7 +1,19 @@
 package com.drs.auralife
 
 import android.app.Application
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
 import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
 
 @HiltAndroidApp
-class AuraLifeApplication : Application()
+class AuraLifeApplication : Application(), Configuration.Provider {
+
+    @Inject
+    lateinit var workerFactory: HiltWorkerFactory
+
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
+}

--- a/app/src/main/java/com/drs/auralife/core/utils/UpdateLibraryWorker.kt
+++ b/app/src/main/java/com/drs/auralife/core/utils/UpdateLibraryWorker.kt
@@ -8,47 +8,28 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import androidx.core.app.NotificationCompat
+import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.drs.auralife.R
 import com.drs.auralife.data.remote.api.FilmAPI
 import com.drs.auralife.data.remote.firebase.LibraryDataSource
-import com.drs.auralife.data.remote.firebase.model.library.Library
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
-import okhttp3.Cache
-import okhttp3.OkHttpClient
-import retrofit2.Retrofit
-import retrofit2.converter.gson.GsonConverterFactory
 import java.util.Locale
 
 const val CHANNEL_ID = "episode_update_channel"
 
-class UpdateLibraryWorker(
-    appContext: Context,
-    workerParams: WorkerParameters,
+@HiltWorker
+class UpdateLibraryWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val api: FilmAPI,
 ) : CoroutineWorker(appContext, workerParams) {
-    private val api: FilmAPI = run {
-        val cacheSize = (5 * 1024 * 1024).toLong()
-        val cache = Cache(applicationContext.cacheDir, cacheSize)
-        val client = OkHttpClient.Builder()
-            .cache(cache)
-            .addInterceptor { chain ->
-                val request = chain.request().newBuilder()
-                    .header("Cache-Control", "public, max-age=${86400}")
-                    .header("Accept", "application/json")
-                    .build()
-                chain.proceed(request)
-            }.build()
-        Retrofit.Builder()
-            .baseUrl("https://phimapi.com")
-            .client(client)
-            .addConverterFactory(GsonConverterFactory.create())
-            .build()
-            .create(FilmAPI::class.java)
-    }
 
     override suspend fun doWork(): Result {
         val updates = checkForNewEpisode()
@@ -99,7 +80,7 @@ class UpdateLibraryWorker(
         return updates
     }
 
-    private suspend fun getLibrary(): List<Library> = LibraryDataSource.getLibrary()
+    private suspend fun getLibrary() = LibraryDataSource.getLibrary()
 
     @SuppressLint("ObsoleteSdkInt")
     private fun sendNotification(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,6 +66,7 @@ firebase-database = { group = "com.google.firebase", name = "firebase-database",
 glide-core = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
+hilt-work = { module = "androidx.hilt:hilt-work", version = "1.2.0" }
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }


### PR DESCRIPTION
## Problem
UpdateLibraryWorker manually created OkHttpClient, Cache, and Retrofit inline, bypassing Hilt DI.

## Solution
- Added \ndroidx.hilt:hilt-work:1.2.0\ dependency
- Annotated \UpdateLibraryWorker\ with \@HiltWorker\ and injected \FilmAPI\ via constructor
- Removed 19 lines of manual OkHttpClient/Retrofit/Cache creation
- Updated \AuraLifeApplication\ to implement \Configuration.Provider\ with \HiltWorkerFactory\

## Benefits
- Worker now uses the same Retrofit/FilmAPI instance as the rest of the app
- No more manual network stack creation in the worker
- Proper Hilt lifecycle management for the worker