### PR TITLE
fix: Clean up listeners to prevent memory leaks

### DIFF
--- a/app/src/main/java/com/drs/auralife/presentation/MainActivity.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/MainActivity.kt
@@ -70,6 +70,7 @@ class MainActivity : AppCompatActivity() {
     private var permissionPhotoHandler: PermissionPhotoHandler? = null
     private lateinit var actionBarDrawerToggle: ActionBarDrawerToggle
     private var searchController: SearchController? = null
+    private var pageChangeCallback: ViewPager2.OnPageChangeCallback? = null
 
     private val authViewModel: AuthViewModel by viewModels()
     private val mainViewModel: MainViewModel by viewModels()
@@ -275,13 +276,12 @@ class MainActivity : AppCompatActivity() {
 
         viewPager.isUserInputEnabled = false
         viewPager.adapter = ViewPagerAdapter(this, fragments)
-        viewPager.registerOnPageChangeCallback(
-            object : ViewPager2.OnPageChangeCallback() {
-                override fun onPageSelected(position: Int) {
-                    bottomNavigationView.menu[position].isChecked = true
-                }
-            },
-        )
+        pageChangeCallback = object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                bottomNavigationView.menu[position].isChecked = true
+            }
+        }
+        viewPager.registerOnPageChangeCallback(pageChangeCallback!!)
 
         bottomNavigationView.setOnItemSelectedListener { item ->
             when (item.itemId) {
@@ -311,6 +311,8 @@ class MainActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         searchController?.destroy()
+        pageChangeCallback?.let { viewPager.unregisterOnPageChangeCallback(it) }
+        drawerLayout.removeDrawerListener(actionBarDrawerToggle)
         super.onDestroy()
     }
 

--- a/app/src/main/java/com/drs/auralife/presentation/explore/ExploreDetailsActivity.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/explore/ExploreDetailsActivity.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
+import android.view.ViewTreeObserver
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
@@ -29,20 +30,9 @@ class ExploreDetailsActivity : AppCompatActivity() {
     private var currentPage = 1
     private var totalPages = 0
     private var currentSlug: String? = null
+    private var scrollListener: ViewTreeObserver.OnScrollChangedListener? = null
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        setContentView(binding.root)
-
-        binding.recyclerView.apply {
-            val displayMetrics = resources.displayMetrics
-            var numberFilmInLine = displayMetrics.widthPixels / displayMetrics.densityDpi
-            layoutManager = GridLayoutManager(this@ExploreDetailsActivity, ++numberFilmInLine)
-            adapter = filmAdapter
-        }
-
-        intent.getStringExtra(CATEGORY_NAME)?.let {
-            @SuppressLint("SetTextI18n")
+    @SuppressLint("SetTextI18n")
             binding.tvNameApp.text = "${binding.tvNameApp.text} - $it"
         }
 
@@ -73,7 +63,7 @@ class ExploreDetailsActivity : AppCompatActivity() {
     }
 
     private fun setupPagination() {
-        binding.recyclerView.viewTreeObserver.addOnScrollChangedListener {
+        scrollListener = ViewTreeObserver.OnScrollChangedListener {
             val lastVisibleItemPosition =
                 (binding.recyclerView.layoutManager as GridLayoutManager).findLastVisibleItemPosition()
             if (lastVisibleItemPosition >= filmAdapter.itemCount - 1 && currentPage < totalPages && !isLoading) {
@@ -84,6 +74,7 @@ class ExploreDetailsActivity : AppCompatActivity() {
                 }
             }
         }
+        binding.recyclerView.viewTreeObserver.addOnScrollChangedListener(scrollListener)
     }
 
     override fun onRestart() {
@@ -97,6 +88,11 @@ class ExploreDetailsActivity : AppCompatActivity() {
     override fun onPause() {
         super.onPause()
         binding.root.isSelected = false
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        scrollListener?.let { binding.recyclerView.viewTreeObserver.removeOnScrollChangedListener(it) }
     }
 
     companion object {

--- a/app/src/main/java/com/drs/auralife/presentation/explore/ExploreDetailsActivity.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/explore/ExploreDetailsActivity.kt
@@ -32,7 +32,19 @@ class ExploreDetailsActivity : AppCompatActivity() {
     private var currentSlug: String? = null
     private var scrollListener: ViewTreeObserver.OnScrollChangedListener? = null
 
-    @SuppressLint("SetTextI18n")
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
+
+        binding.recyclerView.apply {
+            val displayMetrics = resources.displayMetrics
+            var numberFilmInLine = displayMetrics.widthPixels / displayMetrics.densityDpi
+            layoutManager = GridLayoutManager(this@ExploreDetailsActivity, ++numberFilmInLine)
+            adapter = filmAdapter
+        }
+
+        intent.getStringExtra(CATEGORY_NAME)?.let {
+            @SuppressLint("SetTextI18n")
             binding.tvNameApp.text = "${binding.tvNameApp.text} - $it"
         }
 
@@ -74,7 +86,7 @@ class ExploreDetailsActivity : AppCompatActivity() {
                 }
             }
         }
-        binding.recyclerView.viewTreeObserver.addOnScrollChangedListener(scrollListener)
+        binding.recyclerView.viewTreeObserver.addOnScrollChangedListener(scrollListener!!)
     }
 
     override fun onRestart() {

--- a/app/src/main/java/com/drs/auralife/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/home/HomeFragment.kt
@@ -9,6 +9,7 @@ import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewTreeObserver
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -38,6 +39,7 @@ class HomeFragment : Fragment() {
 
     private val bannerHandler = Handler(Looper.getMainLooper())
     private var bannerRunnable: Runnable? = null
+    private var scrollListener: ViewTreeObserver.OnScrollChangedListener? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -81,7 +83,8 @@ class HomeFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        bannerRunnable?.let { bannerHandler.removeCallbacks(it) }
+        scrollListener?.let { binding.recyclerView.viewTreeObserver.removeOnScrollChangedListener(it) }
+        scrollListener = null
         _binding = null
     }
 
@@ -135,8 +138,8 @@ class HomeFragment : Fragment() {
             homeViewModel.getLatestFilms(currentPage)
 
             val layoutManager = binding.recyclerView.layoutManager as GridLayoutManager
-            binding.recyclerView.viewTreeObserver.addOnScrollChangedListener {
-                if (_binding == null) return@addOnScrollChangedListener
+            scrollListener = ViewTreeObserver.OnScrollChangedListener {
+                if (_binding == null) return@OnScrollChangedListener
                 if (currentPage < totalPages) {
                     val lastVisibleItemPosition = layoutManager.findLastVisibleItemPosition()
                     if (!isLoading && lastVisibleItemPosition >= layoutManager.itemCount - 1) {
@@ -153,6 +156,7 @@ class HomeFragment : Fragment() {
                     binding.scrollToTopButton.visibility = View.GONE
                 }
             }
+            binding.recyclerView.viewTreeObserver.addOnScrollChangedListener(scrollListener)
 
             binding.scrollToTopButton.setOnClickListener {
                 binding.recyclerView.smoothScrollToPosition(0)

--- a/app/src/main/java/com/drs/auralife/presentation/search/SearchController.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/search/SearchController.kt
@@ -33,6 +33,7 @@ class SearchController(
     private val filmAdapter = SearchFilmAdapter(mutableListOf())
     private val queryFlow = MutableStateFlow("")
     private var searchIsVisible = false
+    private lateinit var textWatcher: TextWatcher
 
     fun setup() {
         searchResults.layoutManager = LinearLayoutManager(activity)
@@ -59,7 +60,7 @@ class SearchController(
     }
 
     fun destroy() {
-        // no-op: coroutines cancel with lifecycle
+        searchBar.removeTextChangedListener(textWatcher)
     }
 
     private fun hideSearch() {
@@ -97,7 +98,7 @@ class SearchController(
     }
 
     private fun setupTextWatcher() {
-        searchBar.addTextChangedListener(object : TextWatcher {
+        textWatcher = object : TextWatcher {
             override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
             override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
             override fun afterTextChanged(s: Editable?) {
@@ -107,6 +108,7 @@ class SearchController(
                     filmAdapter.replaceItems(emptyList())
                 }
             }
-        })
+        }
+        searchBar.addTextChangedListener(textWatcher)
     }
 }


### PR DESCRIPTION
Fixed 4 listener leaks that were never removed/unregistered:

## Changes

**SearchController** — TextWatcher stored as field, removed in destroy()
**HomeFragment** — OnScrollChangedListener stored as field, removed in onDestroyView()
**MainActivity** — OnPageChangeCallback unregistered and DrawerListener removed in onDestroy()
**ExploreDetailsActivity** — OnScrollChangedListener stored as field, removed in onDestroy()

All listeners are now stored as fields and properly cleaned up in their respective lifecycle callbacks.