### PR TITLE
fix: Replace binding!! with safer error() pattern and fix Handler leaks

### DIFF
--- a/app/src/main/java/com/drs/auralife/presentation/explore/ExploreDetailsActivity.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/explore/ExploreDetailsActivity.kt
@@ -29,6 +29,7 @@ class ExploreDetailsActivity : AppCompatActivity() {
     private var currentPage = 1
     private var totalPages = 0
     private var currentSlug: String? = null
+    private var scrollListener: ViewTreeObserver.OnScrollChangedListener? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -73,7 +74,7 @@ class ExploreDetailsActivity : AppCompatActivity() {
     }
 
     private fun setupPagination() {
-        binding.recyclerView.viewTreeObserver.addOnScrollChangedListener {
+        scrollListener = ViewTreeObserver.OnScrollChangedListener {
             val lastVisibleItemPosition =
                 (binding.recyclerView.layoutManager as GridLayoutManager).findLastVisibleItemPosition()
             if (lastVisibleItemPosition >= filmAdapter.itemCount - 1 && currentPage < totalPages && !isLoading) {
@@ -84,6 +85,7 @@ class ExploreDetailsActivity : AppCompatActivity() {
                 }
             }
         }
+        binding.recyclerView.viewTreeObserver.addOnScrollChangedListener(scrollListener!!)
     }
 
     override fun onRestart() {
@@ -98,6 +100,11 @@ class ExploreDetailsActivity : AppCompatActivity() {
     override fun onPause() {
         super.onPause()
         binding.root.isSelected = false
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        scrollListener?.let { binding.recyclerView.viewTreeObserver.removeOnScrollChangedListener(it) }
     }
 
     companion object {

--- a/app/src/main/java/com/drs/auralife/presentation/explore/ExploreDetailsActivity.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/explore/ExploreDetailsActivity.kt
@@ -4,7 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.os.Handler
+import android.view.ViewTreeObserver
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
@@ -88,10 +88,11 @@ class ExploreDetailsActivity : AppCompatActivity() {
 
     override fun onRestart() {
         super.onRestart()
-        @Suppress("DEPRECATION")
-        Handler().postDelayed({
+        lifecycleScope.launch {
+            kotlinx.coroutines.delay(3000)
+            if (isDestroyed) return@launch
             binding.root.isSelected = true
-        }, 3000)
+        }
     }
 
     override fun onPause() {

--- a/app/src/main/java/com/drs/auralife/presentation/explore/ExploreFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/explore/ExploreFragment.kt
@@ -21,7 +21,7 @@ import java.util.Locale
 class ExploreFragment : Fragment() {
     private val exploreViewModel: ExploreViewModel by viewModels()
     private var _binding: FragmentExploreBinding? = null
-    private val binding get() = _binding!!
+    private val binding get() = _binding ?: error("Binding accessed after onDestroyView")
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/app/src/main/java/com/drs/auralife/presentation/history/HistoryFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/history/HistoryFragment.kt
@@ -21,7 +21,7 @@ class HistoryFragment :
     HistoryFilmAdapter.Listener {
     private val historyViewModel: HistoryViewModel by viewModels()
     private var _binding: FragmentHistoryBinding? = null
-    private val binding get() = _binding!!
+    private val binding get() = _binding ?: error("Binding accessed after onDestroyView")
     private val filmAdapter = HistoryFilmAdapter(mutableListOf())
 
     override fun onCreateView(

--- a/app/src/main/java/com/drs/auralife/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/home/HomeFragment.kt
@@ -32,7 +32,7 @@ class HomeFragment : Fragment() {
     private val filmAdapter = HomeFilmAdapter(mutableListOf())
 
     private var _binding: FragmentHomeBinding? = null
-    private val binding get() = _binding!!
+    private val binding get() = _binding ?: error("Binding accessed after onDestroyView")
 
     private val homeViewModel: HomeViewModel by viewModels()
 

--- a/app/src/main/java/com/drs/auralife/presentation/library/LibraryFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/library/LibraryFragment.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.launch
 @AndroidEntryPoint
 class LibraryFragment : Fragment() {
     private var _binding: FragmentLibraryBinding? = null
-    private val binding get() = _binding!!
+    private val binding get() = _binding ?: error("Binding accessed after onDestroyView")
     private val libraryViewModel: LibraryViewModel by viewModels()
     private lateinit var libraryAdapter: LibraryAdapter
 


### PR DESCRIPTION
High-priority binding null-safety fixes:

**Four fragments** - Replaced _binding!! getter with _binding ?: error("Binding accessed after onDestroyView") for meaningful crash messages instead of cryptic NPE.

**ExploreDetailsActivity** - Replaced Handler().postDelayed() with lifecycleScope.launch + delay() that checks isDestroyed before accessing binding. Prevents stale callbacks after activity destruction.

Total: 5 files changed, safer binding access across the app.
