### PR TITLE
refactor: ViewTreeObserver leak, AuthRepository field injection

### DIFF
--- a/app/src/main/java/com/drs/auralife/presentation/explore/ExploreDetailsActivity.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/explore/ExploreDetailsActivity.kt
@@ -4,7 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.view.ViewTreeObserver
+import androidx.recyclerview.widget.RecyclerView
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
@@ -29,7 +29,7 @@ class ExploreDetailsActivity : AppCompatActivity() {
     private var currentPage = 1
     private var totalPages = 0
     private var currentSlug: String? = null
-    private var scrollListener: ViewTreeObserver.OnScrollChangedListener? = null
+    private var scrollListener: RecyclerView.OnScrollListener? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -74,18 +74,24 @@ class ExploreDetailsActivity : AppCompatActivity() {
     }
 
     private fun setupPagination() {
-        scrollListener = ViewTreeObserver.OnScrollChangedListener {
-            val lastVisibleItemPosition =
-                (binding.recyclerView.layoutManager as GridLayoutManager).findLastVisibleItemPosition()
-            if (lastVisibleItemPosition >= filmAdapter.itemCount - 1 && currentPage < totalPages && !isLoading) {
-                isLoading = true
-                currentPage++
-                currentSlug?.let { slug ->
-                    viewModel.loadMoreFilmsByCategory(slug, currentPage)
+        scrollListener = object : RecyclerView.OnScrollListener() {
+            override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+                val lastVisibleItemPosition =
+                    (recyclerView.layoutManager as GridLayoutManager).findLastVisibleItemPosition()
+                if (lastVisibleItemPosition >= filmAdapter.itemCount - 1 && currentPage < totalPages && !isLoading) {
+                    isLoading = true
+                    currentPage++
+                    currentSlug?.let { slug ->
+                        viewModel.loadMoreFilmsByCategory(slug, currentPage)
+                    }
                 }
             }
         }
+<<<<<<< Updated upstream
         binding.recyclerView.viewTreeObserver.addOnScrollChangedListener(scrollListener!!)
+=======
+        scrollListener?.let { binding.recyclerView.addOnScrollListener(it) }
+>>>>>>> Stashed changes
     }
 
     override fun onRestart() {
@@ -104,7 +110,7 @@ class ExploreDetailsActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        scrollListener?.let { binding.recyclerView.viewTreeObserver.removeOnScrollChangedListener(it) }
+        scrollListener?.let { binding.recyclerView.removeOnScrollListener(it) }
     }
 
     companion object {

--- a/app/src/main/java/com/drs/auralife/presentation/explore/ExploreDetailsActivity.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/explore/ExploreDetailsActivity.kt
@@ -87,11 +87,7 @@ class ExploreDetailsActivity : AppCompatActivity() {
                 }
             }
         }
-<<<<<<< Updated upstream
-        binding.recyclerView.viewTreeObserver.addOnScrollChangedListener(scrollListener!!)
-=======
         scrollListener?.let { binding.recyclerView.addOnScrollListener(it) }
->>>>>>> Stashed changes
     }
 
     override fun onRestart() {

--- a/app/src/main/java/com/drs/auralife/presentation/filmdetails/FilmDetailsActivity.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/filmdetails/FilmDetailsActivity.kt
@@ -22,7 +22,6 @@ import com.drs.auralife.presentation.library.AddToLibraryDialog
 import com.drs.auralife.presentation.library.LibraryViewModel
 import com.drs.auralife.presentation.playfilm.PlayFilmActivity
 import com.drs.auralife.core.utils.MyAppGlideModule
-import javax.inject.Inject
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.first
 
@@ -34,9 +33,6 @@ class FilmDetailsActivity : AppCompatActivity() {
     private val filmDetailsViewModel: FilmDetailsViewModel by viewModels()
     private val libraryViewModel: LibraryViewModel by viewModels()
     private var slug: String? = null
-
-    @Inject
-    lateinit var authRepository: AuthRepository
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -89,7 +85,7 @@ class FilmDetailsActivity : AppCompatActivity() {
         }
 
         binding.addToLibrary.setOnClickListener {
-            if (authRepository.isLoggedIn()) {
+            if (libraryViewModel.isLoggedIn()) {
                 lifecycleScope.launch {
                     libraryViewModel.getLibraries()
                     val libraries = libraryViewModel.librariesLoaded.first()

--- a/app/src/main/java/com/drs/auralife/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/home/HomeFragment.kt
@@ -7,7 +7,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.ViewTreeObserver
+
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -15,6 +15,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.drs.auralife.R
 import com.drs.auralife.databinding.FragmentHomeBinding
 import com.drs.auralife.presentation.AppBarProvider
@@ -37,7 +38,7 @@ class HomeFragment : Fragment() {
     private val homeViewModel: HomeViewModel by viewModels()
     
     private var autoScrollJob: kotlinx.coroutines.Job? = null
-    private var scrollListener: ViewTreeObserver.OnScrollChangedListener? = null
+    private var scrollListener: RecyclerView.OnScrollListener? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -67,7 +68,7 @@ class HomeFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        scrollListener?.let { binding.recyclerView.viewTreeObserver.removeOnScrollChangedListener(it) }
+        scrollListener?.let { binding.recyclerView.removeOnScrollListener(it) }
         scrollListener = null
         _binding = null
     }
@@ -107,26 +108,27 @@ class HomeFragment : Fragment() {
             currentPage = 1
             homeViewModel.getLatestFilms(currentPage)
 
-            val layoutManager = binding.recyclerView.layoutManager as GridLayoutManager
-            scrollListener = ViewTreeObserver.OnScrollChangedListener {
-                if (_binding == null) return@OnScrollChangedListener
-                if (currentPage < totalPages) {
-                    val lastVisibleItemPosition = layoutManager.findLastVisibleItemPosition()
-                    if (!isLoading && lastVisibleItemPosition >= layoutManager.itemCount - 1) {
-                        isLoading = true
-                        currentPage++
-                        homeViewModel.loadMoreLatestFilms(currentPage)
+            scrollListener = object : RecyclerView.OnScrollListener() {
+                override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+                    if (_binding == null) return
+                    val layoutManager = recyclerView.layoutManager as GridLayoutManager
+                    if (currentPage < totalPages) {
+                        val lastVisibleItemPosition = layoutManager.findLastVisibleItemPosition()
+                        if (!isLoading && lastVisibleItemPosition >= layoutManager.itemCount - 1) {
+                            isLoading = true
+                            currentPage++
+                            homeViewModel.loadMoreLatestFilms(currentPage)
+                        }
+                    }
+                    val firstVisibleItemPosition = layoutManager.findFirstVisibleItemPosition()
+                    if (firstVisibleItemPosition > 0) {
+                        binding.scrollToTopButton.visibility = View.VISIBLE
+                    } else {
+                        binding.scrollToTopButton.visibility = View.GONE
                     }
                 }
-
-                val firstVisibleItemPosition = layoutManager.findFirstVisibleItemPosition()
-                if (firstVisibleItemPosition > 0) {
-                    binding.scrollToTopButton.visibility = View.VISIBLE
-                } else {
-                    binding.scrollToTopButton.visibility = View.GONE
-                }
             }
-            binding.recyclerView.viewTreeObserver.addOnScrollChangedListener(scrollListener)
+            scrollListener?.let { binding.recyclerView.addOnScrollListener(it) }
 
             binding.scrollToTopButton.setOnClickListener {
                 binding.recyclerView.smoothScrollToPosition(0)

--- a/app/src/main/java/com/drs/auralife/presentation/library/LibraryFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/library/LibraryFragment.kt
@@ -11,11 +11,9 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.drs.auralife.R
 import com.drs.auralife.databinding.FragmentLibraryBinding
-import com.drs.auralife.domain.repository.AuthRepository
 import com.drs.auralife.presentation.AppBarProvider
 import com.drs.auralife.presentation.common.UiState
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
@@ -24,9 +22,6 @@ class LibraryFragment : Fragment() {
     private val binding get() = _binding ?: error("Binding accessed after onDestroyView")
     private val libraryViewModel: LibraryViewModel by viewModels()
     private lateinit var libraryAdapter: LibraryAdapter
-
-    @Inject
-    lateinit var authRepository: AuthRepository
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -77,7 +72,7 @@ class LibraryFragment : Fragment() {
                         val libraries = state.data
                         libraryAdapter.refreshLibrary(libraries.toMutableList())
 
-                        if (!authRepository.isLoggedIn()) {
+                        if (!libraryViewModel.isLoggedIn()) {
                             binding.text.visibility = View.VISIBLE
                             binding.text.text = getString(R.string.function_must_login)
                         } else if (libraries.isEmpty()) {

--- a/app/src/main/java/com/drs/auralife/presentation/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/library/LibraryViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.drs.auralife.domain.model.Film
 import com.drs.auralife.domain.model.Library
 import com.drs.auralife.domain.model.LibraryFilm
+import com.drs.auralife.domain.repository.AuthRepository
 import com.drs.auralife.domain.usecase.AddToLibraryUseCase
 import com.drs.auralife.domain.usecase.CreateLibraryUseCase
 import com.drs.auralife.domain.usecase.DeleteLibraryUseCase
@@ -34,7 +35,10 @@ class LibraryViewModel @Inject constructor(
     private val renameLibraryUseCase: RenameLibraryUseCase,
     private val deleteLibraryUseCase: DeleteLibraryUseCase,
     private val getFilmDetailsUseCase: GetFilmDetailsUseCase,
+    private val authRepository: AuthRepository,
 ) : ViewModel() {
+
+    fun isLoggedIn() = authRepository.isLoggedIn()
 
     private val _librariesState = MutableStateFlow<UiState<List<Library>>>(UiState.Loading)
     val librariesState: StateFlow<UiState<List<Library>>> = _librariesState.asStateFlow()

--- a/app/src/main/java/com/drs/auralife/presentation/playfilm/PlayFilmActivity.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/playfilm/PlayFilmActivity.kt
@@ -24,13 +24,11 @@ import androidx.recyclerview.widget.RecyclerView
 import com.drs.auralife.R
 import com.drs.auralife.presentation.filmdetails.FilmDetailsViewModel
 import com.drs.auralife.domain.model.FilmDetails
-import com.drs.auralife.domain.repository.AuthRepository
 import com.drs.auralife.presentation.history.HistoryViewModel
 import com.drs.auralife.presentation.auth.LoginActivity
 import com.drs.auralife.presentation.filmdetails.EXTRA_SLUG
 import com.drs.auralife.presentation.payment.PaymentActivity
 import com.drs.auralife.core.utils.SystemUiController
-import javax.inject.Inject
 import kotlinx.coroutines.launch
 
 @dagger.hilt.android.AndroidEntryPoint
@@ -39,9 +37,6 @@ class PlayFilmActivity : AppCompatActivity() {
     private val historyViewModel: HistoryViewModel by viewModels()
     private val playFilmViewModel: PlayFilmViewModel by viewModels()
     private var recyclerView: RecyclerView? = null
-
-    @Inject
-    lateinit var authRepository: AuthRepository
 
     private var exoPlayer: ExoPlayer? = null
     private var playerView: PlayerView? = null
@@ -298,7 +293,7 @@ class PlayFilmActivity : AppCompatActivity() {
         }
 
         btnCreate.setOnClickListener {
-            if (authRepository.isLoggedIn()) {
+            if (playFilmViewModel.isLoggedIn()) {
                 val intent = Intent(this, PaymentActivity::class.java)
                 startActivity(intent)
             } else {

--- a/app/src/main/java/com/drs/auralife/presentation/playfilm/PlayFilmViewModel.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/playfilm/PlayFilmViewModel.kt
@@ -2,6 +2,7 @@ package com.drs.auralife.presentation.playfilm
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.drs.auralife.domain.repository.AuthRepository
 import com.drs.auralife.domain.usecase.GetPremiumStatusUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -16,7 +17,10 @@ import javax.inject.Inject
 @HiltViewModel
 class PlayFilmViewModel @Inject constructor(
     private val getPremiumStatusUseCase: GetPremiumStatusUseCase,
+    private val authRepository: AuthRepository,
 ) : ViewModel() {
+
+    fun isLoggedIn() = authRepository.isLoggedIn()
 
     private val _throttleEvent = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val throttleEvent: SharedFlow<Unit> = _throttleEvent.asSharedFlow()


### PR DESCRIPTION
## Summary

P1 fixes for ViewTreeObserver memory leak and AuthRepository field injection.

### Changes

#### ViewTreeObserver → RecyclerView.OnScrollListener
- **HomeFragment.kt**: Replaced ViewTreeObserver.OnScrollChangedListener with RecyclerView.OnScrollListener with proper onScrolled() override. Listener is properly removed in onDestroyView().
- **ExploreDetailsActivity.kt**: Same fix. Listener removed in onDestroy().

#### AuthRepository field injection → ViewModel
- **LibraryViewModel.kt**: Added AuthRepository as constructor parameter, exposed isLoggedIn() method
- **PlayFilmViewModel.kt**: Same pattern
- **LibraryFragment.kt**: Removed @Inject lateinit var authRepository, uses libraryViewModel.isLoggedIn()
- **FilmDetailsActivity.kt**: Removed @Inject lateinit var authRepository, uses libraryViewModel.isLoggedIn()
- **PlayFilmActivity.kt**: Removed @Inject lateinit var authRepository, uses playFilmViewModel.isLoggedIn()

### Verification
- Build: \./gradlew assembleDebug\ ✅