### PR TITLE
fix: migrate all adapters to AsyncListDiffer (DiffUtil)

### DIFF
--- a/app/src/main/java/com/drs/auralife/presentation/explore/CategoryFilmAdapter.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/explore/CategoryFilmAdapter.kt
@@ -6,6 +6,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.recyclerview.widget.AsyncListDiffer
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.drs.auralife.R
 import com.drs.auralife.domain.model.Film
@@ -13,9 +15,12 @@ import com.drs.auralife.presentation.filmdetails.FilmDetailsActivity
 import com.drs.auralife.presentation.filmdetails.EXTRA_SLUG
 import com.drs.auralife.core.utils.MyAppGlideModule
 
-class CategoryFilmAdapter(
-    private val films: MutableList<Film>,
-) : RecyclerView.Adapter<CategoryFilmAdapter.ViewHolder>() {
+class CategoryFilmAdapter : RecyclerView.Adapter<CategoryFilmAdapter.ViewHolder>() {
+
+    private val differ = AsyncListDiffer(this, object : DiffUtil.ItemCallback<Film>() {
+        override fun areItemsTheSame(oldItem: Film, newItem: Film): Boolean = oldItem.slug == newItem.slug
+        override fun areContentsTheSame(oldItem: Film, newItem: Film): Boolean = oldItem == newItem
+    })
 
     class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         val ivPoster: ImageView = itemView.findViewById(R.id.posterView)
@@ -30,7 +35,7 @@ class CategoryFilmAdapter(
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        val film = films[position]
+        val film = differ.currentList[position]
         holder.apply {
             tvTitle.textAlignment = View.TEXT_ALIGNMENT_CENTER
             tvDetails.textAlignment = View.TEXT_ALIGNMENT_CENTER
@@ -45,17 +50,18 @@ class CategoryFilmAdapter(
         }
     }
 
-    override fun getItemCount(): Int = films.size
+    override fun getItemCount(): Int = differ.currentList.size
 
     fun addItem(newItems: List<Film>) {
+        val current = differ.currentList.toMutableList()
         newItems.forEach { film ->
-            if (films.map { it.slug }.contains(film.slug)) {
-                val position = films.indexOfFirst { it.slug == film.slug }
-                films[position] = film
+            val existingIndex = current.indexOfFirst { it.slug == film.slug }
+            if (existingIndex != -1) {
+                current[existingIndex] = film
             } else {
-                films.add(film)
+                current.add(film)
             }
         }
-        notifyItemInserted(films.size)
+        differ.submitList(current)
     }
 }

--- a/app/src/main/java/com/drs/auralife/presentation/explore/ExploreDetailsActivity.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/explore/ExploreDetailsActivity.kt
@@ -24,7 +24,7 @@ private const val CATEGORY_NAME = "NAME_CATEGORY"
 class ExploreDetailsActivity : AppCompatActivity() {
     private val binding by lazy { ActivityExploreDetailsBinding.inflate(layoutInflater) }
     private val viewModel: ExploreDetailViewModel by viewModels()
-    private val filmAdapter by lazy { ExploreFilmAdapter(mutableListOf()) }
+    private val filmAdapter by lazy { ExploreFilmAdapter() }
     private var isLoading = false
     private var currentPage = 1
     private var totalPages = 0

--- a/app/src/main/java/com/drs/auralife/presentation/explore/ExploreFilmAdapter.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/explore/ExploreFilmAdapter.kt
@@ -6,6 +6,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.recyclerview.widget.AsyncListDiffer
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.drs.auralife.R
 import com.drs.auralife.domain.model.Film
@@ -13,9 +15,12 @@ import com.drs.auralife.presentation.filmdetails.FilmDetailsActivity
 import com.drs.auralife.presentation.filmdetails.EXTRA_SLUG
 import com.drs.auralife.core.utils.MyAppGlideModule
 
-class ExploreFilmAdapter(
-    private val films: MutableList<Film>,
-) : RecyclerView.Adapter<ExploreFilmAdapter.ViewHolder>() {
+class ExploreFilmAdapter : RecyclerView.Adapter<ExploreFilmAdapter.ViewHolder>() {
+
+    private val differ = AsyncListDiffer(this, object : DiffUtil.ItemCallback<Film>() {
+        override fun areItemsTheSame(oldItem: Film, newItem: Film): Boolean = oldItem.slug == newItem.slug
+        override fun areContentsTheSame(oldItem: Film, newItem: Film): Boolean = oldItem == newItem
+    })
 
     class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         val ivPoster: ImageView = itemView.findViewById(R.id.posterView)
@@ -30,7 +35,7 @@ class ExploreFilmAdapter(
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        val film = films[position]
+        val film = differ.currentList[position]
         holder.apply {
             tvTitle.textAlignment = View.TEXT_ALIGNMENT_CENTER
             tvDetails.textAlignment = View.TEXT_ALIGNMENT_CENTER
@@ -45,11 +50,9 @@ class ExploreFilmAdapter(
         }
     }
 
-    override fun getItemCount(): Int = films.size
+    override fun getItemCount(): Int = differ.currentList.size
 
     fun replaceItems(newItems: List<Film>) {
-        films.clear()
-        films.addAll(newItems)
-        notifyDataSetChanged()
+        differ.submitList(newItems)
     }
 }

--- a/app/src/main/java/com/drs/auralife/presentation/explore/ExploreFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/explore/ExploreFragment.kt
@@ -57,7 +57,7 @@ class ExploreFragment : Fragment() {
                     startActivity(ExploreDetailsActivity.newInstance(currentContext, category))
                 }
 
-            val filmAdapter = CategoryFilmAdapter(mutableListOf())
+            val filmAdapter = CategoryFilmAdapter()
             item.findViewById<RecyclerView>(R.id.recyclerView).adapter = filmAdapter
             binding.exploreFragmentBody.addView(item)
 

--- a/app/src/main/java/com/drs/auralife/presentation/history/HistoryFilmAdapter.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/history/HistoryFilmAdapter.kt
@@ -6,6 +6,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.recyclerview.widget.AsyncListDiffer
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.drs.auralife.R
 import com.drs.auralife.domain.model.Film
@@ -13,9 +15,12 @@ import com.drs.auralife.presentation.filmdetails.FilmDetailsActivity
 import com.drs.auralife.presentation.filmdetails.EXTRA_SLUG
 import com.drs.auralife.core.utils.MyAppGlideModule
 
-class HistoryFilmAdapter(
-    private val films: MutableList<Film>,
-) : RecyclerView.Adapter<HistoryFilmAdapter.ViewHolder>() {
+class HistoryFilmAdapter : RecyclerView.Adapter<HistoryFilmAdapter.ViewHolder>() {
+
+    private val differ = AsyncListDiffer(this, object : DiffUtil.ItemCallback<Film>() {
+        override fun areItemsTheSame(oldItem: Film, newItem: Film): Boolean = oldItem.slug == newItem.slug
+        override fun areContentsTheSame(oldItem: Film, newItem: Film): Boolean = oldItem == newItem
+    })
 
     interface Listener {
         fun onLongClick(slug: String)
@@ -40,7 +45,7 @@ class HistoryFilmAdapter(
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        val film = films[position]
+        val film = differ.currentList[position]
         holder.apply {
             tvTitle.textAlignment = View.TEXT_ALIGNMENT_CENTER
             tvDetails.textAlignment = View.TEXT_ALIGNMENT_CENTER
@@ -59,16 +64,13 @@ class HistoryFilmAdapter(
         }
     }
 
-    override fun getItemCount(): Int = films.size
+    override fun getItemCount(): Int = differ.currentList.size
 
     fun replaceItems(newItems: List<Film>) {
-        films.clear()
-        films.addAll(newItems)
-        notifyDataSetChanged()
+        differ.submitList(newItems)
     }
 
     fun clearItems() {
-        films.clear()
-        notifyDataSetChanged()
+        differ.submitList(emptyList())
     }
 }

--- a/app/src/main/java/com/drs/auralife/presentation/history/HistoryFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/history/HistoryFragment.kt
@@ -22,7 +22,7 @@ class HistoryFragment :
     private val historyViewModel: HistoryViewModel by viewModels()
     private var _binding: FragmentHistoryBinding? = null
     private val binding get() = _binding ?: error("Binding accessed after onDestroyView")
-    private val filmAdapter = HistoryFilmAdapter(mutableListOf())
+    private val filmAdapter = HistoryFilmAdapter()
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/app/src/main/java/com/drs/auralife/presentation/home/HomeFilmAdapter.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/home/HomeFilmAdapter.kt
@@ -6,6 +6,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.recyclerview.widget.AsyncListDiffer
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.drs.auralife.R
 import com.drs.auralife.domain.model.Film
@@ -13,9 +15,12 @@ import com.drs.auralife.presentation.filmdetails.FilmDetailsActivity
 import com.drs.auralife.presentation.filmdetails.EXTRA_SLUG
 import com.drs.auralife.core.utils.MyAppGlideModule
 
-class HomeFilmAdapter(
-    private val films: MutableList<Film>,
-) : RecyclerView.Adapter<HomeFilmAdapter.ViewHolder>() {
+class HomeFilmAdapter : RecyclerView.Adapter<HomeFilmAdapter.ViewHolder>() {
+
+    private val differ = AsyncListDiffer(this, object : DiffUtil.ItemCallback<Film>() {
+        override fun areItemsTheSame(oldItem: Film, newItem: Film): Boolean = oldItem.slug == newItem.slug
+        override fun areContentsTheSame(oldItem: Film, newItem: Film): Boolean = oldItem == newItem
+    })
 
     class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         val ivPoster: ImageView = itemView.findViewById(R.id.posterView)
@@ -30,7 +35,7 @@ class HomeFilmAdapter(
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        val film = films[position]
+        val film = differ.currentList[position]
         holder.apply {
             tvTitle.textAlignment = View.TEXT_ALIGNMENT_CENTER
             tvDetails.textAlignment = View.TEXT_ALIGNMENT_CENTER
@@ -45,11 +50,9 @@ class HomeFilmAdapter(
         }
     }
 
-    override fun getItemCount(): Int = films.size
+    override fun getItemCount(): Int = differ.currentList.size
 
     fun replaceItems(newItems: List<Film>) {
-        films.clear()
-        films.addAll(newItems)
-        notifyDataSetChanged()
+        differ.submitList(newItems)
     }
 }

--- a/app/src/main/java/com/drs/auralife/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/home/HomeFragment.kt
@@ -29,7 +29,7 @@ class HomeFragment : Fragment() {
     private var isLoading = false
     private var currentPage = 1
     private var totalPages = 0
-    private val filmAdapter = HomeFilmAdapter(mutableListOf())
+    private val filmAdapter = HomeFilmAdapter()
 
     private var _binding: FragmentHomeBinding? = null
     private val binding get() = _binding ?: error("Binding accessed after onDestroyView")

--- a/app/src/main/java/com/drs/auralife/presentation/library/LibraryAdapter.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/library/LibraryAdapter.kt
@@ -7,16 +7,22 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.recyclerview.widget.AsyncListDiffer
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.drs.auralife.R
 import com.drs.auralife.core.utils.MyAppGlideModule
 import com.drs.auralife.domain.model.Library
 
 class LibraryAdapter(
-    private val library: MutableList<Library>,
     private val onRename: (oldName: String, newName: String) -> Unit,
     private val onDelete: (name: String) -> Unit,
 ) : RecyclerView.Adapter<LibraryAdapter.ItemViewHolder>() {
+
+    private val differ = AsyncListDiffer(this, object : DiffUtil.ItemCallback<Library>() {
+        override fun areItemsTheSame(oldItem: Library, newItem: Library): Boolean = oldItem.name == newItem.name
+        override fun areContentsTheSame(oldItem: Library, newItem: Library): Boolean = oldItem == newItem
+    })
     class ItemViewHolder(
         itemView: View,
     ) : RecyclerView.ViewHolder(itemView) {
@@ -38,7 +44,7 @@ class LibraryAdapter(
         holder: ItemViewHolder,
         position: Int,
     ) {
-        val item = library[position]
+        val item = differ.currentList[position]
         val context = holder.itemView.context
 
         MyAppGlideModule.loadImage(context, item.posterUrl, holder.tvImage)
@@ -65,13 +71,10 @@ class LibraryAdapter(
         }
     }
 
-    override fun getItemCount() = library.size
+    override fun getItemCount() = differ.currentList.size
 
-    @SuppressLint("NotifyDataSetChanged")
     fun refreshLibrary(newLibrary: MutableList<Library>) {
-        library.clear()
-        library.addAll(newLibrary)
-        library.sortBy { it.name }
-        notifyDataSetChanged()
+        newLibrary.sortBy { it.name }
+        differ.submitList(newLibrary)
     }
 }

--- a/app/src/main/java/com/drs/auralife/presentation/library/LibraryDetailsActivity.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/library/LibraryDetailsActivity.kt
@@ -19,7 +19,7 @@ class LibraryDetailsActivity :
     LibraryFilmAdapter.Listener {
     private val binding by lazy { ActivityLibraryDetailsBinding.inflate(layoutInflater) }
     private val libraryViewModel: LibraryViewModel by viewModels()
-    private val filmAdapter = LibraryFilmAdapter(mutableListOf())
+    private val filmAdapter = LibraryFilmAdapter()
     private var libraryName: String? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/drs/auralife/presentation/library/LibraryFilmAdapter.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/library/LibraryFilmAdapter.kt
@@ -6,6 +6,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.recyclerview.widget.AsyncListDiffer
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.drs.auralife.R
 import com.drs.auralife.domain.model.Film
@@ -13,9 +15,12 @@ import com.drs.auralife.presentation.filmdetails.FilmDetailsActivity
 import com.drs.auralife.presentation.filmdetails.EXTRA_SLUG
 import com.drs.auralife.core.utils.MyAppGlideModule
 
-class LibraryFilmAdapter(
-    private val films: MutableList<Film>,
-) : RecyclerView.Adapter<LibraryFilmAdapter.ViewHolder>() {
+class LibraryFilmAdapter : RecyclerView.Adapter<LibraryFilmAdapter.ViewHolder>() {
+
+    private val differ = AsyncListDiffer(this, object : DiffUtil.ItemCallback<Film>() {
+        override fun areItemsTheSame(oldItem: Film, newItem: Film): Boolean = oldItem.slug == newItem.slug
+        override fun areContentsTheSame(oldItem: Film, newItem: Film): Boolean = oldItem == newItem
+    })
 
     interface Listener {
         fun onLongClick(slug: String)
@@ -40,7 +45,7 @@ class LibraryFilmAdapter(
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        val film = films[position]
+        val film = differ.currentList[position]
         holder.apply {
             tvTitle.textAlignment = View.TEXT_ALIGNMENT_TEXT_START
             tvDetails.textAlignment = View.TEXT_ALIGNMENT_TEXT_START
@@ -59,19 +64,14 @@ class LibraryFilmAdapter(
         }
     }
 
-    override fun getItemCount(): Int = films.size
+    override fun getItemCount(): Int = differ.currentList.size
 
     fun replaceItems(newItems: List<Film>) {
-        films.clear()
-        films.addAll(newItems)
-        notifyDataSetChanged()
+        differ.submitList(newItems)
     }
 
     fun removeItem(slug: String) {
-        val position = films.indexOfFirst { it.slug == slug }
-        if (position != -1) {
-            films.removeAt(position)
-            notifyItemRemoved(position)
-        }
+        val updated = differ.currentList.filter { it.slug != slug }
+        differ.submitList(updated)
     }
 }

--- a/app/src/main/java/com/drs/auralife/presentation/library/LibraryFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/library/LibraryFragment.kt
@@ -44,7 +44,6 @@ class LibraryFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         libraryAdapter = LibraryAdapter(
-            library = mutableListOf(),
             onRename = { oldName, newName ->
                 libraryViewModel.renameLibrary(oldName, newName)
             },

--- a/app/src/main/java/com/drs/auralife/presentation/search/SearchController.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/search/SearchController.kt
@@ -30,7 +30,7 @@ class SearchController(
     private val bottomNav: View,
 ) {
     private val searchViewModel: SearchViewModel by activity.viewModels()
-    private val filmAdapter = SearchFilmAdapter(mutableListOf())
+    private val filmAdapter = SearchFilmAdapter()
     private val queryFlow = MutableStateFlow("")
     private var searchIsVisible = false
     private lateinit var textWatcher: TextWatcher

--- a/app/src/main/java/com/drs/auralife/presentation/search/SearchFilmAdapter.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/search/SearchFilmAdapter.kt
@@ -6,6 +6,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.recyclerview.widget.AsyncListDiffer
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.drs.auralife.R
 import com.drs.auralife.domain.model.Film
@@ -13,9 +15,12 @@ import com.drs.auralife.presentation.filmdetails.FilmDetailsActivity
 import com.drs.auralife.presentation.filmdetails.EXTRA_SLUG
 import com.drs.auralife.core.utils.MyAppGlideModule
 
-class SearchFilmAdapter(
-    private val filmList: MutableList<Film>,
-) : RecyclerView.Adapter<SearchFilmAdapter.ViewHolder>() {
+class SearchFilmAdapter : RecyclerView.Adapter<SearchFilmAdapter.ViewHolder>() {
+
+    private val differ = AsyncListDiffer(this, object : DiffUtil.ItemCallback<Film>() {
+        override fun areItemsTheSame(oldItem: Film, newItem: Film): Boolean = oldItem.slug == newItem.slug
+        override fun areContentsTheSame(oldItem: Film, newItem: Film): Boolean = oldItem == newItem
+    })
 
     class ViewHolder(
         itemView: View,
@@ -39,7 +44,7 @@ class SearchFilmAdapter(
         holder: ViewHolder,
         position: Int,
     ) {
-        val film = filmList[position]
+        val film = differ.currentList[position]
         holder.tvTitle.text = film.title
         holder.tvDetails.text = film.description
         MyAppGlideModule.loadImage(
@@ -54,11 +59,9 @@ class SearchFilmAdapter(
         }
     }
 
-    override fun getItemCount(): Int = filmList.size
+    override fun getItemCount(): Int = differ.currentList.size
 
     fun replaceItems(newItems: List<Film>) {
-        filmList.clear()
-        filmList.addAll(newItems)
-        notifyDataSetChanged()
+        differ.submitList(newItems)
     }
 }


### PR DESCRIPTION
Replace 
otifyDataSetChanged() with AsyncListDiffer across all 7 adapters for efficient RecyclerView diffing.

### Changed
- **SearchFilmAdapter** — ilms → differ.currentList, eplaceItems() uses differ.submitList()
- **ExploreFilmAdapter** — same pattern
- **HomeFilmAdapter** — same pattern
- **HistoryFilmAdapter** — same pattern (including clearItems())
- **LibraryFilmAdapter** — same pattern (including emoveItem())
- **CategoryFilmAdapter** — same pattern (including ddItem())
- **LibraryAdapter** — same pattern (including efreshLibrary(), removed library constructor param)

### Removed
- MutableList constructor parameter from all adapters
- 
otifyDataSetChanged() calls throughout