### PR TITLE
fix: unify ViewModel state management with UiState sealed class

### DIFF
--- a/app/src/main/java/com/drs/auralife/presentation/explore/ExploreDetailViewModel.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/explore/ExploreDetailViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.drs.auralife.domain.model.Film
 import com.drs.auralife.domain.usecase.GetFilmsByCategoryUseCase
+import com.drs.auralife.presentation.common.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -11,46 +12,42 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+data class CategoryFilmsData(
+    val films: List<Film>,
+    val totalPages: Int,
+)
+
 @HiltViewModel
 class ExploreDetailViewModel @Inject constructor(
     private val getFilmsByCategoryUseCase: GetFilmsByCategoryUseCase,
 ) : ViewModel() {
 
-    private val _categoryFilmsState = MutableStateFlow<List<Film>>(emptyList())
-    val categoryFilmsState: StateFlow<List<Film>> = _categoryFilmsState.asStateFlow()
-
-    private val _categoryTotalPages = MutableStateFlow(0)
-    val categoryTotalPages: StateFlow<Int> = _categoryTotalPages.asStateFlow()
-
-    private val _isLoadingState = MutableStateFlow(false)
-    val isLoadingState: StateFlow<Boolean> = _isLoadingState.asStateFlow()
-
-    private val _errorState = MutableStateFlow<String?>(null)
-    val errorState: StateFlow<String?> = _errorState.asStateFlow()
+    private val _categoryFilmsState = MutableStateFlow<UiState<CategoryFilmsData>>(UiState.Loading)
+    val categoryFilmsState: StateFlow<UiState<CategoryFilmsData>> = _categoryFilmsState.asStateFlow()
 
     fun getFilmsByCategory(slug: String, page: Int) {
         viewModelScope.launch {
+            _categoryFilmsState.value = UiState.Loading
             try {
-                _isLoadingState.value = true
-                _errorState.value = null
                 val result = getFilmsByCategoryUseCase(slug, page)
-                _categoryFilmsState.value = result.data
-                _categoryTotalPages.value = result.totalPages
+                _categoryFilmsState.value = UiState.Success(CategoryFilmsData(result.data, result.totalPages))
             } catch (e: Exception) {
-                _errorState.value = e.message
-            } finally {
-                _isLoadingState.value = false
+                _categoryFilmsState.value = UiState.Error(e.message ?: "Failed to load films")
             }
         }
     }
 
     fun loadMoreFilmsByCategory(slug: String, page: Int) {
         viewModelScope.launch {
-            try {
-                val result = getFilmsByCategoryUseCase(slug, page)
-                _categoryFilmsState.value = _categoryFilmsState.value + result.data
-            } catch (e: Exception) {
-                _errorState.value = e.message
+            val current = _categoryFilmsState.value
+            if (current is UiState.Success) {
+                try {
+                    val result = getFilmsByCategoryUseCase(slug, page)
+                    val appended = current.data.films + result.data
+                    _categoryFilmsState.value = UiState.Success(current.data.copy(films = appended))
+                } catch (e: Exception) {
+                    _categoryFilmsState.value = UiState.Error(e.message ?: "Failed to load more")
+                }
             }
         }
     }

--- a/app/src/main/java/com/drs/auralife/presentation/explore/ExploreDetailsActivity.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/explore/ExploreDetailsActivity.kt
@@ -4,16 +4,17 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.view.ViewTreeObserver
+import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.drs.auralife.domain.model.Category
 import com.drs.auralife.databinding.ActivityExploreDetailsBinding
-import com.drs.auralife.domain.model.Film
+import com.drs.auralife.presentation.common.UiState
 import java.util.Locale
 import kotlinx.coroutines.launch
 
@@ -29,7 +30,6 @@ class ExploreDetailsActivity : AppCompatActivity() {
     private var currentPage = 1
     private var totalPages = 0
     private var currentSlug: String? = null
-    private var scrollListener: ViewTreeObserver.OnScrollChangedListener? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -58,34 +58,39 @@ class ExploreDetailsActivity : AppCompatActivity() {
     private fun observeCategoryFilms() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.categoryFilmsState.collect { films ->
-                    filmAdapter.replaceItems(films)
-                    isLoading = false
-                }
-            }
-        }
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.categoryTotalPages.collect { pages ->
-                    totalPages = pages
+                viewModel.categoryFilmsState.collect { state ->
+                    when (state) {
+                        is UiState.Success -> {
+                            filmAdapter.replaceItems(state.data.films)
+                            totalPages = state.data.totalPages
+                            isLoading = false
+                        }
+                        is UiState.Error -> {
+                            Toast.makeText(this@ExploreDetailsActivity, state.message, Toast.LENGTH_SHORT).show()
+                            isLoading = false
+                        }
+                        is UiState.Loading -> isLoading = true
+                    }
                 }
             }
         }
     }
 
     private fun setupPagination() {
-        scrollListener = ViewTreeObserver.OnScrollChangedListener {
-            val lastVisibleItemPosition =
-                (binding.recyclerView.layoutManager as GridLayoutManager).findLastVisibleItemPosition()
-            if (lastVisibleItemPosition >= filmAdapter.itemCount - 1 && currentPage < totalPages && !isLoading) {
-                isLoading = true
-                currentPage++
-                currentSlug?.let { slug ->
-                    viewModel.loadMoreFilmsByCategory(slug, currentPage)
+        binding.recyclerView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+            override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+                super.onScrolled(recyclerView, dx, dy)
+                val lastVisibleItemPosition =
+                    (recyclerView.layoutManager as GridLayoutManager).findLastVisibleItemPosition()
+                if (lastVisibleItemPosition >= filmAdapter.itemCount - 1 && currentPage < totalPages && !isLoading) {
+                    isLoading = true
+                    currentPage++
+                    currentSlug?.let { slug ->
+                        viewModel.loadMoreFilmsByCategory(slug, currentPage)
+                    }
                 }
             }
-        }
-        binding.recyclerView.viewTreeObserver.addOnScrollChangedListener(scrollListener!!)
+        })
     }
 
     override fun onRestart() {
@@ -100,11 +105,6 @@ class ExploreDetailsActivity : AppCompatActivity() {
     override fun onPause() {
         super.onPause()
         binding.root.isSelected = false
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        scrollListener?.let { binding.recyclerView.viewTreeObserver.removeOnScrollChangedListener(it) }
     }
 
     companion object {

--- a/app/src/main/java/com/drs/auralife/presentation/explore/ExploreFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/explore/ExploreFragment.kt
@@ -7,11 +7,14 @@ import android.view.ViewGroup
 import androidx.appcompat.widget.AppCompatButton
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.RecyclerView
 import com.drs.auralife.R
 import com.drs.auralife.databinding.FragmentExploreBinding
 import com.drs.auralife.presentation.AppBarProvider
+import com.drs.auralife.presentation.common.UiState
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -38,10 +41,14 @@ class ExploreFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        lifecycleScope.launch {
-            exploreViewModel.categoriesState.collect { categories ->
-                if (_binding == null || categories.isEmpty()) return@collect
-                buildCategoryViews(categories)
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                exploreViewModel.categoriesState.collect { state ->
+                    if (_binding == null) return@collect
+                    if (state is UiState.Success && state.data.isNotEmpty()) {
+                        buildCategoryViews(state.data)
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/drs/auralife/presentation/explore/ExploreViewModel.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/explore/ExploreViewModel.kt
@@ -7,6 +7,7 @@ import com.drs.auralife.domain.model.Category
 import com.drs.auralife.domain.model.Film
 import com.drs.auralife.domain.usecase.GetCategoriesUseCase
 import com.drs.auralife.domain.usecase.GetFilmsByCategoryUseCase
+import com.drs.auralife.presentation.common.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -20,21 +21,17 @@ class ExploreViewModel @Inject constructor(
     private val getFilmsByCategoryUseCase: GetFilmsByCategoryUseCase,
 ) : ViewModel() {
 
-    private val _categoriesState = MutableStateFlow<List<Category>>(emptyList())
-    val categoriesState: StateFlow<List<Category>> = _categoriesState.asStateFlow()
-
-    private val _isLoading = MutableStateFlow(false)
-    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+    private val _categoriesState = MutableStateFlow<UiState<List<Category>>>(UiState.Loading)
+    val categoriesState: StateFlow<UiState<List<Category>>> = _categoriesState.asStateFlow()
 
     fun loadCategories() {
         viewModelScope.launch {
-            _isLoading.value = true
+            _categoriesState.value = UiState.Loading
             try {
-                _categoriesState.value = getCategoriesUseCase()
+                _categoriesState.value = UiState.Success(getCategoriesUseCase())
             } catch (e: Exception) {
                 Log.e("ExploreViewModel", "loadCategories failed", e)
-            } finally {
-                _isLoading.value = false
+                _categoriesState.value = UiState.Error(e.message ?: "Failed to load categories")
             }
         }
     }

--- a/app/src/main/java/com/drs/auralife/presentation/filmdetails/FilmDetailsActivity.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/filmdetails/FilmDetailsActivity.kt
@@ -18,6 +18,7 @@ import com.drs.auralife.databinding.ActivityFilmDetailsBinding
 import com.drs.auralife.domain.model.FilmDetails
 import com.drs.auralife.domain.repository.AuthRepository
 import com.drs.auralife.presentation.auth.LoginActivity
+import com.drs.auralife.presentation.common.UiState
 import com.drs.auralife.presentation.library.AddToLibraryDialog
 import com.drs.auralife.presentation.library.LibraryViewModel
 import com.drs.auralife.presentation.playfilm.PlayFilmActivity
@@ -52,8 +53,18 @@ class FilmDetailsActivity : AppCompatActivity() {
     private fun observeFilmDetails() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                filmDetailsViewModel.filmDetailsState.collect { film ->
-                    film?.let { updateUI(it) }
+                filmDetailsViewModel.filmDetailsState.collect { state ->
+                    when (state) {
+                        is UiState.Loading -> binding.root.visibility = View.GONE
+                        is UiState.Success -> {
+                            binding.root.visibility = View.VISIBLE
+                            updateUI(state.data)
+                        }
+                        is UiState.Error -> {
+                            binding.root.visibility = View.GONE
+                            Toast.makeText(this@FilmDetailsActivity, state.message, Toast.LENGTH_SHORT).show()
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/drs/auralife/presentation/filmdetails/FilmDetailsViewModel.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/filmdetails/FilmDetailsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.drs.auralife.domain.model.FilmDetails
 import com.drs.auralife.domain.usecase.GetFilmDetailsUseCase
+import com.drs.auralife.presentation.common.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -16,26 +17,21 @@ class FilmDetailsViewModel @Inject constructor(
     private val getFilmDetailsUseCase: GetFilmDetailsUseCase,
 ) : ViewModel() {
 
-    private val _filmDetailsState = MutableStateFlow<FilmDetails?>(null)
-    val filmDetailsState: StateFlow<FilmDetails?> = _filmDetailsState.asStateFlow()
-
-    private val _isLoadingState = MutableStateFlow(false)
-    val isLoadingState: StateFlow<Boolean> = _isLoadingState.asStateFlow()
-
-    private val _errorState = MutableStateFlow<String?>(null)
-    val errorState: StateFlow<String?> = _errorState.asStateFlow()
+    private val _filmDetailsState = MutableStateFlow<UiState<FilmDetails>>(UiState.Loading)
+    val filmDetailsState: StateFlow<UiState<FilmDetails>> = _filmDetailsState.asStateFlow()
 
     fun getFilmDetails(slug: String) {
         viewModelScope.launch {
+            _filmDetailsState.value = UiState.Loading
             try {
-                _isLoadingState.value = true
-                _errorState.value = null
                 val details = getFilmDetailsUseCase(slug)
-                _filmDetailsState.value = details
+                if (details != null) {
+                    _filmDetailsState.value = UiState.Success(details)
+                } else {
+                    _filmDetailsState.value = UiState.Error("Film not found")
+                }
             } catch (e: Exception) {
-                _errorState.value = e.message
-            } finally {
-                _isLoadingState.value = false
+                _filmDetailsState.value = UiState.Error(e.message ?: "Unknown error")
             }
         }
     }

--- a/app/src/main/java/com/drs/auralife/presentation/playfilm/PlayFilmActivity.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/playfilm/PlayFilmActivity.kt
@@ -27,6 +27,7 @@ import com.drs.auralife.domain.model.FilmDetails
 import com.drs.auralife.domain.repository.AuthRepository
 import com.drs.auralife.presentation.history.HistoryViewModel
 import com.drs.auralife.presentation.auth.LoginActivity
+import com.drs.auralife.presentation.common.UiState
 import com.drs.auralife.presentation.filmdetails.EXTRA_SLUG
 import com.drs.auralife.presentation.payment.PaymentActivity
 import com.drs.auralife.core.utils.SystemUiController
@@ -108,11 +109,11 @@ class PlayFilmActivity : AppCompatActivity() {
     private fun observeFilmDetails() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                filmDetailsViewModel.filmDetailsState.collect { details ->
-                    details?.let {
-                        film = it
+                filmDetailsViewModel.filmDetailsState.collect { state ->
+                    if (state is UiState.Success) {
+                        film = state.data
                         playEpisode(currentEpisode)
-                        recyclerView?.adapter = EpisodeAdapter(it.episodes) { ep ->
+                        recyclerView?.adapter = EpisodeAdapter(state.data.episodes) { ep ->
                             playEpisode(ep)
                         }
                     }

--- a/app/src/main/java/com/drs/auralife/presentation/search/SearchController.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/search/SearchController.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.drs.auralife.presentation.common.UiState
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -76,8 +77,10 @@ class SearchController(
     private fun observeSearchResults() {
         activity.lifecycleScope.launch {
             activity.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                searchViewModel.searchResultsState.collect { results ->
-                    filmAdapter.replaceItems(results)
+                searchViewModel.searchResultsState.collect { state ->
+                    if (state is UiState.Success) {
+                        filmAdapter.replaceItems(state.data)
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/drs/auralife/presentation/search/SearchViewModel.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/search/SearchViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.drs.auralife.domain.model.Film
 import com.drs.auralife.domain.usecase.SearchFilmsUseCase
+import com.drs.auralife.presentation.common.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -16,26 +17,17 @@ class SearchViewModel @Inject constructor(
     private val searchFilmsUseCase: SearchFilmsUseCase,
 ) : ViewModel() {
 
-    private val _searchResultsState = MutableStateFlow<List<Film>>(emptyList())
-    val searchResultsState: StateFlow<List<Film>> = _searchResultsState.asStateFlow()
-
-    private val _isLoadingState = MutableStateFlow(false)
-    val isLoadingState: StateFlow<Boolean> = _isLoadingState.asStateFlow()
-
-    private val _errorState = MutableStateFlow<String?>(null)
-    val errorState: StateFlow<String?> = _errorState.asStateFlow()
+    private val _searchResultsState = MutableStateFlow<UiState<List<Film>>>(UiState.Success(emptyList()))
+    val searchResultsState: StateFlow<UiState<List<Film>>> = _searchResultsState.asStateFlow()
 
     fun searchFilms(keyword: String, limit: Int) {
         viewModelScope.launch {
+            _searchResultsState.value = UiState.Loading
             try {
-                _isLoadingState.value = true
-                _errorState.value = null
                 val films = searchFilmsUseCase(keyword, limit)
-                _searchResultsState.value = films
+                _searchResultsState.value = UiState.Success(films)
             } catch (e: Exception) {
-                _errorState.value = e.message
-            } finally {
-                _isLoadingState.value = false
+                _searchResultsState.value = UiState.Error(e.message ?: "Search failed")
             }
         }
     }


### PR DESCRIPTION
### Summary

Migrate 4 ViewModels from **split-flow pattern** (separate StateFlow<data>, StateFlow<loading>, StateFlow<error>) to the canonical **UiState<T> sealed class** pattern already used by HomeViewModel, LibraryViewModel, and HistoryViewModel.

### Changed ViewModels

| ViewModel | Before | After |
|---|---|---|
| FilmDetailsViewModel | 3 flows: FilmDetails? + Boolean + String? | UiState<FilmDetails> |
| SearchViewModel | 3 flows: List<Film> + Boolean + String? | UiState<List<Film>> |
| ExploreViewModel | 2 flows: List<Category> + Boolean (no error) | UiState<List<Category>> + error handling |
| ExploreDetailViewModel | 4 flows: List<Film> + Int + Boolean + String? | UiState<CategoryFilmsData> (new wrapper with ilms + 	otalPages) |

### Updated Consumers
- FilmDetailsActivity — when-branches on UiState.Loading/Success/Error
- PlayFilmActivity — handles UiState.Success
- SearchController — handles UiState.Success
- ExploreFragment — removed direct categoriesState collection, uses UiState
- ExploreDetailsActivity — consolidated multi-collector into single UiState collector; also replaced ViewTreeObserver.OnScrollChangedListener → RecyclerView.OnScrollListener

### Additional Fixes
- Added missing epeatOnLifecycle(STARTED) to ExploreFragment state collection
- Added CategoryFilmsData data class in ExploreDetailViewModel.kt for paginated category films