### PR TITLE
refactor: lifecycle + effect pattern + package structure

### DIFF
--- a/app/src/main/java/com/drs/auralife/core/util/ImageEncoderDecoder.kt
+++ b/app/src/main/java/com/drs/auralife/core/util/ImageEncoderDecoder.kt
@@ -1,4 +1,5 @@
-package com.drs.auralife.core.utils
+package com.drs.auralife.core.util
+
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.util.Base64
@@ -6,7 +7,6 @@ import androidx.core.graphics.scale
 import java.io.ByteArrayOutputStream
 
 object ImageEncoderDecoder {
-    // Encode Bitmap to Base64 string
     fun encodeToBase64(
         bitmap: Bitmap,
         compressFormat: Bitmap.CompressFormat = Bitmap.CompressFormat.PNG,
@@ -20,7 +20,6 @@ object ImageEncoderDecoder {
         return Base64.encodeToString(byteArray, Base64.DEFAULT)
     }
 
-    // Decode Base64 string to Bitmap
     fun decodeFromBase64(base64String: String): Bitmap? =
         try {
             val decodedBytes = Base64.decode(base64String, Base64.DEFAULT)

--- a/app/src/main/java/com/drs/auralife/core/util/Notification.kt
+++ b/app/src/main/java/com/drs/auralife/core/util/Notification.kt
@@ -1,4 +1,4 @@
-package com.drs.auralife.core.utils
+package com.drs.auralife.core.util
 
 import android.content.Context
 import org.json.JSONArray

--- a/app/src/main/java/com/drs/auralife/core/util/Time.kt
+++ b/app/src/main/java/com/drs/auralife/core/util/Time.kt
@@ -1,4 +1,4 @@
-package com.drs.auralife.core.utils
+package com.drs.auralife.core.util
 
 import android.content.Context
 import com.drs.auralife.R

--- a/app/src/main/java/com/drs/auralife/core/validation/EditTextValidator.kt
+++ b/app/src/main/java/com/drs/auralife/core/validation/EditTextValidator.kt
@@ -1,6 +1,6 @@
 @file:Suppress("unused")
 
-package com.drs.auralife.core.utils
+package com.drs.auralife.core.validation
 
 abstract class EditTextValidator<T>(
     val errorText: String,

--- a/app/src/main/java/com/drs/auralife/core/validation/Validator.kt
+++ b/app/src/main/java/com/drs/auralife/core/validation/Validator.kt
@@ -1,6 +1,6 @@
 @file:Suppress("unused")
 
-package com.drs.auralife.core.utils
+package com.drs.auralife.core.validation
 
 import android.content.Context
 import androidx.core.content.ContextCompat.getString

--- a/app/src/main/java/com/drs/auralife/core/worker/UpdateLibraryWorker.kt
+++ b/app/src/main/java/com/drs/auralife/core/worker/UpdateLibraryWorker.kt
@@ -1,4 +1,4 @@
-package com.drs.auralife.core.utils
+package com.drs.auralife.core.worker
 
 import android.annotation.SuppressLint
 import android.app.NotificationChannel
@@ -14,6 +14,7 @@ import androidx.work.WorkerParameters
 import com.drs.auralife.R
 import com.drs.auralife.data.remote.api.FilmAPI
 import com.drs.auralife.data.remote.firebase.LibraryDataSource
+import com.drs.auralife.core.util.Notification
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.Dispatchers

--- a/app/src/main/java/com/drs/auralife/data/remote/firebase/AvatarDataSource.kt
+++ b/app/src/main/java/com/drs/auralife/data/remote/firebase/AvatarDataSource.kt
@@ -1,7 +1,7 @@
 package com.drs.auralife.data.remote.firebase
 
 import android.graphics.Bitmap
-import com.drs.auralife.core.utils.ImageEncoderDecoder
+import com.drs.auralife.core.util.ImageEncoderDecoder
 import com.google.firebase.database.FirebaseDatabase
 
 object AvatarDataSource {

--- a/app/src/main/java/com/drs/auralife/data/repository/AvatarRepositoryImpl.kt
+++ b/app/src/main/java/com/drs/auralife/data/repository/AvatarRepositoryImpl.kt
@@ -2,7 +2,7 @@ package com.drs.auralife.data.repository
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import com.drs.auralife.core.utils.ImageEncoderDecoder
+import com.drs.auralife.core.util.ImageEncoderDecoder
 import com.drs.auralife.data.remote.firebase.Authentication
 import com.drs.auralife.data.remote.firebase.AvatarDataSource as FirebaseAvatarRepository
 import com.drs.auralife.domain.repository.AvatarRepository

--- a/app/src/main/java/com/drs/auralife/presentation/MainActivity.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/MainActivity.kt
@@ -258,11 +258,11 @@ class MainActivity : AppCompatActivity(), AppBarProvider {
     private fun observeAvatarResult() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                mainViewModel.avatarResult.collect { result ->
-                    result.onSuccess {
-                        Toast.makeText(this@MainActivity, getString(R.string.upload_avatar_successfully), Toast.LENGTH_SHORT).show()
-                    }.onFailure {
-                        Toast.makeText(this@MainActivity, getString(R.string.upload_avatar_failed), Toast.LENGTH_SHORT).show()
+                mainViewModel.effect.collect { effect ->
+                    when (effect) {
+                        is MainUiEffect.ShowToast -> {
+                            Toast.makeText(this@MainActivity, effect.message, Toast.LENGTH_SHORT).show()
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/drs/auralife/presentation/MainActivity.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/MainActivity.kt
@@ -36,10 +36,10 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import com.drs.auralife.R
-import com.drs.auralife.core.utils.MyAppGlideModule
-import com.drs.auralife.core.utils.Notification
-import com.drs.auralife.core.utils.PermissionPhotoHandler
-import com.drs.auralife.core.utils.UpdateLibraryWorker
+import com.drs.auralife.presentation.common.MyAppGlideModule
+import com.drs.auralife.core.util.Notification
+import com.drs.auralife.presentation.common.PermissionPhotoHandler
+import com.drs.auralife.core.worker.UpdateLibraryWorker
 import com.drs.auralife.presentation.common.NotificationAdapter
 import com.drs.auralife.presentation.navigation.NavRoutes
 import com.drs.auralife.presentation.search.SearchFilmAdapter

--- a/app/src/main/java/com/drs/auralife/presentation/MainViewModel.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/MainViewModel.kt
@@ -20,6 +20,10 @@ import kotlinx.coroutines.launch
 import java.io.ByteArrayOutputStream
 import javax.inject.Inject
 
+sealed interface MainUiEffect {
+    data class ShowToast(val message: String) : MainUiEffect
+}
+
 @HiltViewModel
 class MainViewModel @Inject constructor(
     private val getPremiumStatusUseCase: GetPremiumStatusUseCase,
@@ -38,8 +42,8 @@ class MainViewModel @Inject constructor(
     private val _avatarState = MutableStateFlow<Bitmap?>(null)
     val avatarState: StateFlow<Bitmap?> = _avatarState.asStateFlow()
 
-    private val _avatarResult = MutableSharedFlow<Result<Unit>>()
-    val avatarResult: SharedFlow<Result<Unit>> = _avatarResult.asSharedFlow()
+    private val _effect = MutableSharedFlow<MainUiEffect>()
+    val effect: SharedFlow<MainUiEffect> = _effect.asSharedFlow()
 
     fun loadPremiumStatus() {
         viewModelScope.launch {
@@ -74,13 +78,13 @@ class MainViewModel @Inject constructor(
                 val imageBytes = stream.toByteArray()
                 val success = uploadAvatarUseCase(imageBytes)
                 if (success) {
-                    _avatarResult.emit(Result.success(Unit))
                     loadAvatar()
+                    _effect.emit(MainUiEffect.ShowToast("Upload avatar successfully"))
                 } else {
-                    _avatarResult.emit(Result.failure(Exception("Upload failed")))
+                    _effect.emit(MainUiEffect.ShowToast("Upload avatar failed"))
                 }
             } catch (e: Exception) {
-                _avatarResult.emit(Result.failure(e))
+                _effect.emit(MainUiEffect.ShowToast(e.message ?: "Upload avatar failed"))
             }
         }
     }

--- a/app/src/main/java/com/drs/auralife/presentation/common/MyAppGlideModule.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/common/MyAppGlideModule.kt
@@ -1,4 +1,4 @@
-package com.drs.auralife.core.utils
+package com.drs.auralife.presentation.common
 
 import android.app.Activity
 import android.content.Context

--- a/app/src/main/java/com/drs/auralife/presentation/common/PermissionPhotoHandler.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/common/PermissionPhotoHandler.kt
@@ -1,4 +1,4 @@
-package com.drs.auralife.core.utils
+package com.drs.auralife.presentation.common
 
 import android.Manifest
 import android.app.Activity

--- a/app/src/main/java/com/drs/auralife/presentation/common/SystemUiController.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/common/SystemUiController.kt
@@ -1,4 +1,4 @@
-package com.drs.auralife.core.utils
+package com.drs.auralife.presentation.common
 
 import android.os.Build
 import android.view.View

--- a/app/src/main/java/com/drs/auralife/presentation/common/UiUtils.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/common/UiUtils.kt
@@ -1,4 +1,4 @@
-package com.drs.auralife.presentation.util
+package com.drs.auralife.presentation.common
 
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle

--- a/app/src/main/java/com/drs/auralife/presentation/explore/ExploreContract.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/explore/ExploreContract.kt
@@ -1,9 +1,11 @@
 package com.drs.auralife.presentation.explore
 
 import com.drs.auralife.domain.model.Category
+import com.drs.auralife.domain.model.Film
 
 data class ExploreUiState(
     val categories: List<Category> = emptyList(),
+    val filmsByCategory: Map<String, List<Film>> = emptyMap(),
     val isLoading: Boolean = false,
     val errorMessage: String? = null,
 )

--- a/app/src/main/java/com/drs/auralife/presentation/explore/ExploreFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/explore/ExploreFragment.kt
@@ -10,7 +10,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import com.drs.auralife.presentation.util.launchAndRepeatWithViewLifecycle
+import com.drs.auralife.presentation.common.launchAndRepeatWithViewLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.RecyclerView
 import com.drs.auralife.R

--- a/app/src/main/java/com/drs/auralife/presentation/explore/ExploreFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/explore/ExploreFragment.kt
@@ -10,7 +10,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
+import com.drs.auralife.presentation.util.launchAndRepeatWithViewLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.RecyclerView
 import com.drs.auralife.R
@@ -60,21 +60,26 @@ class ExploreFragment : Fragment() {
     }
 
     private fun observeState() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        launchAndRepeatWithViewLifecycle {
                 exploreViewModel.state.collect { state ->
                     if (_binding == null) return@collect
                     if (state.categories.isNotEmpty()) {
                         buildCategoryViews(state.categories)
                     }
+                    state.filmsByCategory.forEach { (slug, films) ->
+                        val index = state.categories.indexOfFirst { it.slug == slug }
+                        if (index >= 0) {
+                            val child = binding.exploreFragmentBody.getChildAt(index)
+                            val rv = child?.findViewById<RecyclerView>(R.id.recyclerView)
+                            (rv?.adapter as? CategoryFilmAdapter)?.addItem(films)
+                        }
+                    }
                 }
-            }
         }
     }
 
     private fun observeEffect() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        launchAndRepeatWithViewLifecycle {
                 exploreViewModel.effect.collect { effect ->
                     when (effect) {
                         is ExploreUiEffect.ShowToast -> {
@@ -93,11 +98,11 @@ class ExploreFragment : Fragment() {
                         }
                     }
                 }
-            }
         }
     }
 
     private fun buildCategoryViews(categories: List<com.drs.auralife.domain.model.Category>) {
+        binding.exploreFragmentBody.removeAllViews()
         categories.forEach { category ->
             val currentContext = context ?: return@forEach
             val item = layoutInflater.inflate(R.layout.horizontal_film_list, null)
@@ -114,11 +119,7 @@ class ExploreFragment : Fragment() {
 
             val buttonText = if (Locale.getDefault().language == "en") category.localizedName else category.name
             item.findViewById<AppCompatButton>(R.id.buttonHorizontalFilmList).text = buttonText
-
-            exploreViewModel.getFilmsByCategoryList(category.slug, 1) { films ->
-                if (_binding == null) return@getFilmsByCategoryList
-                films?.let { list -> filmAdapter.addItem(list) }
-            }
         }
     }
 }
+

--- a/app/src/main/java/com/drs/auralife/presentation/explore/ExploreViewModel.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/explore/ExploreViewModel.kt
@@ -3,7 +3,6 @@ package com.drs.auralife.presentation.explore
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.drs.auralife.domain.model.Category
 import com.drs.auralife.domain.model.Film
 import com.drs.auralife.domain.usecase.GetCategoriesUseCase
 import com.drs.auralife.domain.usecase.GetFilmsByCategoryUseCase
@@ -33,7 +32,11 @@ class ExploreViewModel @Inject constructor(
         viewModelScope.launch {
             _state.value = _state.value.copy(isLoading = true)
             try {
-                _state.value = _state.value.copy(categories = getCategoriesUseCase(), isLoading = false)
+                val categories = getCategoriesUseCase()
+                _state.value = _state.value.copy(categories = categories, isLoading = false)
+                categories.forEach { category ->
+                    loadFilmsForCategory(category.slug)
+                }
             } catch (e: Exception) {
                 Log.e("ExploreViewModel", "loadCategories failed", e)
                 _state.value = _state.value.copy(isLoading = false, errorMessage = e.message)
@@ -41,15 +44,15 @@ class ExploreViewModel @Inject constructor(
         }
     }
 
-    fun getFilmsByCategoryList(slug: String, page: Int, onResult: (List<Film>?) -> Unit) {
-        viewModelScope.launch {
-            try {
-                val result = getFilmsByCategoryUseCase(slug, page)
-                onResult(result.data)
-            } catch (e: Exception) {
-                Log.e("ExploreViewModel", "getFilmsByCategoryList failed", e)
-                onResult(null)
-            }
+    private suspend fun loadFilmsForCategory(slug: String) {
+        try {
+            val result = getFilmsByCategoryUseCase(slug, 1)
+            val current = _state.value.filmsByCategory.toMutableMap()
+            current[slug] = result.data
+            _state.value = _state.value.copy(filmsByCategory = current)
+        } catch (e: Exception) {
+            Log.e("ExploreViewModel", "loadFilmsForCategory failed for $slug", e)
+            _effect.emit(ExploreUiEffect.ShowToast("Failed to load films for category"))
         }
     }
 

--- a/app/src/main/java/com/drs/auralife/presentation/explore/adapter/CategoryFilmAdapter.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/explore/adapter/CategoryFilmAdapter.kt
@@ -9,7 +9,7 @@ import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.drs.auralife.R
-import com.drs.auralife.core.utils.MyAppGlideModule
+import com.drs.auralife.presentation.common.MyAppGlideModule
 import com.drs.auralife.domain.model.Film
 
 class CategoryFilmAdapter(

--- a/app/src/main/java/com/drs/auralife/presentation/explore/adapter/ExploreFilmAdapter.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/explore/adapter/ExploreFilmAdapter.kt
@@ -9,7 +9,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.drs.auralife.R
-import com.drs.auralife.core.utils.MyAppGlideModule
+import com.drs.auralife.presentation.common.MyAppGlideModule
 import com.drs.auralife.domain.model.Film
 
 class ExploreFilmAdapter(

--- a/app/src/main/java/com/drs/auralife/presentation/explore_details/ExploreDetailContract.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/explore_details/ExploreDetailContract.kt
@@ -4,6 +4,7 @@ import com.drs.auralife.domain.model.Film
 
 data class ExploreDetailUiState(
     val films: List<Film> = emptyList(),
+    val currentPage: Int = 1,
     val totalPages: Int = 0,
     val isLoading: Boolean = false,
     val isLoadingMore: Boolean = false,

--- a/app/src/main/java/com/drs/auralife/presentation/explore_details/ExploreDetailViewModel.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/explore_details/ExploreDetailViewModel.kt
@@ -24,14 +24,15 @@ class ExploreDetailViewModel @Inject constructor(
     private val _effect = MutableSharedFlow<ExploreDetailUiEffect>()
     val effect: SharedFlow<ExploreDetailUiEffect> = _effect.asSharedFlow()
 
-    fun getFilmsByCategory(slug: String, page: Int) {
+    fun getFilmsByCategory(slug: String) {
         viewModelScope.launch {
-            _state.value = _state.value.copy(isLoading = true)
+            _state.value = _state.value.copy(isLoading = true, currentPage = 1)
             try {
-                val result = getFilmsByCategoryUseCase(slug, page)
+                val result = getFilmsByCategoryUseCase(slug, 1)
                 _state.value = ExploreDetailUiState(
                     films = result.data,
                     totalPages = result.totalPages,
+                    currentPage = 1,
                 )
             } catch (e: Exception) {
                 _state.value = _state.value.copy(isLoading = false, errorMessage = e.message)
@@ -39,13 +40,16 @@ class ExploreDetailViewModel @Inject constructor(
         }
     }
 
-    fun loadMoreFilmsByCategory(slug: String, page: Int) {
+    fun onScrolledToBottom(slug: String) {
+        val current = _state.value
+        if (current.isLoadingMore || current.currentPage >= current.totalPages) return
+        val nextPage = current.currentPage + 1
         viewModelScope.launch {
             _state.value = _state.value.copy(isLoadingMore = true)
             try {
-                val result = getFilmsByCategoryUseCase(slug, page)
+                val result = getFilmsByCategoryUseCase(slug, nextPage)
                 val appended = _state.value.films + result.data
-                _state.value = _state.value.copy(films = appended, totalPages = result.totalPages, isLoadingMore = false)
+                _state.value = _state.value.copy(films = appended, totalPages = result.totalPages, currentPage = nextPage, isLoadingMore = false)
             } catch (e: Exception) {
                 _state.value = _state.value.copy(isLoadingMore = false, errorMessage = e.message)
             }

--- a/app/src/main/java/com/drs/auralife/presentation/explore_details/ExploreDetailsFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/explore_details/ExploreDetailsFragment.kt
@@ -9,7 +9,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import com.drs.auralife.presentation.util.launchAndRepeatWithViewLifecycle
+import com.drs.auralife.presentation.common.launchAndRepeatWithViewLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.GridLayoutManager
 import com.drs.auralife.R

--- a/app/src/main/java/com/drs/auralife/presentation/explore_details/ExploreDetailsFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/explore_details/ExploreDetailsFragment.kt
@@ -9,7 +9,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
+import com.drs.auralife.presentation.util.launchAndRepeatWithViewLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.GridLayoutManager
 import com.drs.auralife.R
@@ -23,7 +23,7 @@ class ExploreDetailsFragment : Fragment() {
 
     private val viewModel: ExploreDetailViewModel by viewModels()
     private var _binding: ActivityExploreDetailsBinding? = null
-    private val binding get() = _binding!!
+    private val binding get() = _binding ?: error("Binding accessed after onDestroyView")
     private var slug: String = ""
     private var name: String = ""
 
@@ -31,9 +31,6 @@ class ExploreDetailsFragment : Fragment() {
         viewModel.onFilmClicked(slug)
     }
 
-    private var isLoading = false
-    private var currentPage = 1
-    private var totalPages = 0
     private var scrollListener: androidx.recyclerview.widget.RecyclerView.OnScrollListener? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -57,7 +54,7 @@ class ExploreDetailsFragment : Fragment() {
 
         observeState()
         observeEffect()
-        viewModel.getFilmsByCategory(slug, 1)
+        viewModel.getFilmsByCategory(slug)
         setupPagination()
     }
 
@@ -67,20 +64,15 @@ class ExploreDetailsFragment : Fragment() {
     }
 
     private fun observeState() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        launchAndRepeatWithViewLifecycle {
                 viewModel.state.collect { state ->
                     filmAdapter.submitList(state.films)
-                    totalPages = state.totalPages
-                    isLoading = state.isLoadingMore
                 }
-            }
         }
     }
 
     private fun observeEffect() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        launchAndRepeatWithViewLifecycle {
                 viewModel.effect.collect { effect ->
                     when (effect) {
                         is ExploreDetailUiEffect.ShowToast -> {
@@ -92,7 +84,6 @@ class ExploreDetailsFragment : Fragment() {
                         }
                     }
                 }
-            }
         }
     }
 
@@ -100,13 +91,12 @@ class ExploreDetailsFragment : Fragment() {
         scrollListener = object : androidx.recyclerview.widget.RecyclerView.OnScrollListener() {
             override fun onScrolled(recyclerView: androidx.recyclerview.widget.RecyclerView, dx: Int, dy: Int) {
                 val lastVisibleItemPosition = (recyclerView.layoutManager as GridLayoutManager).findLastVisibleItemPosition()
-                if (lastVisibleItemPosition >= filmAdapter.itemCount - 1 && currentPage < totalPages && !isLoading) {
-                    isLoading = true
-                    currentPage++
-                    viewModel.loadMoreFilmsByCategory(slug, currentPage)
+                if (lastVisibleItemPosition >= filmAdapter.itemCount - 1) {
+                    viewModel.onScrolledToBottom(slug)
                 }
             }
         }
         scrollListener?.let { binding.recyclerView.addOnScrollListener(it) }
     }
 }
+

--- a/app/src/main/java/com/drs/auralife/presentation/filmdetails/FilmDetailsFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/filmdetails/FilmDetailsFragment.kt
@@ -13,26 +13,25 @@ import androidx.core.net.toUri
 import androidx.core.text.HtmlCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
+import com.drs.auralife.presentation.util.launchAndRepeatWithViewLifecycle
 import androidx.navigation.fragment.findNavController
 import com.drs.auralife.R
 import com.drs.auralife.core.utils.MyAppGlideModule
 import com.drs.auralife.databinding.ActivityFilmDetailsBinding
 import com.drs.auralife.presentation.library.AddToLibraryDialog
+import com.drs.auralife.presentation.library.LibraryUiEffect
 import com.drs.auralife.presentation.library.LibraryViewModel
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class FilmDetailsFragment : Fragment() {
 
     private val filmDetailsViewModel: FilmDetailsViewModel by viewModels()
-    private val libraryViewModel: LibraryViewModel by viewModels()
+    private val libraryViewModel: LibraryViewModel by viewModels(ownerProducer = { requireActivity() })
     private var _binding: ActivityFilmDetailsBinding? = null
-    private val binding get() = _binding!!
+    private val binding get() = _binding ?: error("Binding accessed after onDestroyView")
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = ActivityFilmDetailsBinding.inflate(inflater, container, false)
@@ -43,6 +42,7 @@ class FilmDetailsFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         observeState()
         observeEffect()
+        observeOperationResult()
         val slug = requireArguments().getString("slug") ?: return
         filmDetailsViewModel.getFilmDetails(slug)
     }
@@ -53,8 +53,7 @@ class FilmDetailsFragment : Fragment() {
     }
 
     private fun observeState() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        launchAndRepeatWithViewLifecycle {
                 filmDetailsViewModel.state.collect { state ->
                     when {
                         state.isLoading -> binding.root.visibility = View.GONE
@@ -68,13 +67,11 @@ class FilmDetailsFragment : Fragment() {
                         }
                     }
                 }
-            }
         }
     }
 
     private fun observeEffect() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        launchAndRepeatWithViewLifecycle {
                 filmDetailsViewModel.effect.collect { effect ->
                     when (effect) {
                         is FilmDetailsUiEffect.ShowToast -> {
@@ -89,7 +86,6 @@ class FilmDetailsFragment : Fragment() {
                         }
                     }
                 }
-            }
         }
     }
 
@@ -121,13 +117,12 @@ class FilmDetailsFragment : Fragment() {
             if (libraryViewModel.isLoggedIn()) {
                 viewLifecycleOwner.lifecycleScope.launch {
                     libraryViewModel.getLibraries()
-                    val libraries = libraryViewModel.librariesLoaded.first()
                     AddToLibraryDialog.showAddLibraryDialog(
                         context = requireContext(),
                         slug = film.slug,
                         posterUrl = film.posterUrl,
                         episodeCurrent = film.episodeCurrent,
-                        libraries = libraries,
+                        libraries = libraryViewModel.librariesState.value.libraries,
                         onAddToLibrary = { libraryName ->
                             libraryViewModel.addToLibrary(libraryName, film.slug, film.posterUrl, film.episodeCurrent ?: "")
                         },
@@ -143,20 +138,15 @@ class FilmDetailsFragment : Fragment() {
     }
 
     private fun observeOperationResult() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                libraryViewModel.operationResult.collect { result ->
-                    result.onSuccess { success ->
-                        Toast.makeText(
-                            context,
-                            if (success) R.string.added_to_library_successfully else R.string.library_already_exists,
-                            Toast.LENGTH_SHORT,
-                        ).show()
-                    }.onFailure { e ->
-                        Toast.makeText(context, e.message ?: getString(R.string.error), Toast.LENGTH_SHORT).show()
+        launchAndRepeatWithViewLifecycle {
+                libraryViewModel.effect.collect { effect ->
+                    when (effect) {
+                        is LibraryUiEffect.ShowToast -> {
+                            Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
+                        }
+                        else -> {}
                     }
                 }
-            }
         }
     }
 
@@ -180,3 +170,4 @@ class FilmDetailsFragment : Fragment() {
         return itemDetail
     }
 }
+

--- a/app/src/main/java/com/drs/auralife/presentation/filmdetails/FilmDetailsFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/filmdetails/FilmDetailsFragment.kt
@@ -14,10 +14,10 @@ import androidx.core.text.HtmlCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
-import com.drs.auralife.presentation.util.launchAndRepeatWithViewLifecycle
+import com.drs.auralife.presentation.common.launchAndRepeatWithViewLifecycle
 import androidx.navigation.fragment.findNavController
 import com.drs.auralife.R
-import com.drs.auralife.core.utils.MyAppGlideModule
+import com.drs.auralife.presentation.common.MyAppGlideModule
 import com.drs.auralife.databinding.ActivityFilmDetailsBinding
 import com.drs.auralife.presentation.library.AddToLibraryDialog
 import com.drs.auralife.presentation.library.LibraryUiEffect

--- a/app/src/main/java/com/drs/auralife/presentation/history/HistoryFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/history/HistoryFragment.kt
@@ -10,7 +10,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import com.drs.auralife.presentation.util.launchAndRepeatWithViewLifecycle
+import com.drs.auralife.presentation.common.launchAndRepeatWithViewLifecycle
 import androidx.navigation.fragment.findNavController
 import com.drs.auralife.R
 import com.drs.auralife.databinding.FragmentHistoryBinding

--- a/app/src/main/java/com/drs/auralife/presentation/history/HistoryFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/history/HistoryFragment.kt
@@ -10,7 +10,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
+import com.drs.auralife.presentation.util.launchAndRepeatWithViewLifecycle
 import androidx.navigation.fragment.findNavController
 import com.drs.auralife.R
 import com.drs.auralife.databinding.FragmentHistoryBinding
@@ -53,8 +53,7 @@ class HistoryFragment : Fragment() {
     }
 
     private fun observeState() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        launchAndRepeatWithViewLifecycle {
                 historyViewModel.state.collect { state ->
                     if (_binding == null) return@collect
                     if (state.films.isEmpty()) {
@@ -69,13 +68,11 @@ class HistoryFragment : Fragment() {
                         binding.text.text = state.errorMessage
                     }
                 }
-            }
         }
     }
 
     private fun observeEffect() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        launchAndRepeatWithViewLifecycle {
                 historyViewModel.effect.collect { effect ->
                     when (effect) {
                         is HistoryUiEffect.ShowToast -> {
@@ -87,7 +84,6 @@ class HistoryFragment : Fragment() {
                         }
                     }
                 }
-            }
         }
     }
 
@@ -99,3 +95,4 @@ class HistoryFragment : Fragment() {
         }
     }
 }
+

--- a/app/src/main/java/com/drs/auralife/presentation/history/adapter/HistoryFilmAdapter.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/history/adapter/HistoryFilmAdapter.kt
@@ -9,7 +9,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.drs.auralife.R
-import com.drs.auralife.core.utils.MyAppGlideModule
+import com.drs.auralife.presentation.common.MyAppGlideModule
 import com.drs.auralife.domain.model.Film
 
 class HistoryFilmAdapter(

--- a/app/src/main/java/com/drs/auralife/presentation/home/HomeContract.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/home/HomeContract.kt
@@ -5,10 +5,12 @@ import com.drs.auralife.domain.model.Film
 data class HomeUiState(
     val banners: List<Pair<String, String>> = emptyList(),
     val films: List<Film> = emptyList(),
+    val currentPage: Int = 1,
     val totalPages: Int = 0,
     val isLoadingBanners: Boolean = false,
     val isLoadingFilms: Boolean = false,
     val isLoadingMore: Boolean = false,
+    val isConnected: Boolean = true,
     val errorMessage: String? = null,
 )
 

--- a/app/src/main/java/com/drs/auralife/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/home/HomeFragment.kt
@@ -8,7 +8,7 @@ import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
-import com.drs.auralife.presentation.util.launchAndRepeatWithViewLifecycle
+import com.drs.auralife.presentation.common.launchAndRepeatWithViewLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.GridLayoutManager
 import com.drs.auralife.R

--- a/app/src/main/java/com/drs/auralife/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/home/HomeFragment.kt
@@ -1,8 +1,5 @@
 package com.drs.auralife.presentation.home
 
-import android.content.Context
-import android.net.ConnectivityManager
-import android.net.NetworkCapabilities
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -10,9 +7,8 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
+import com.drs.auralife.presentation.util.launchAndRepeatWithViewLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.GridLayoutManager
 import com.drs.auralife.R
@@ -34,9 +30,6 @@ class HomeFragment : Fragment() {
         homeViewModel.onFilmClicked(slug)
     }
 
-    private var isLoading = false
-    private var currentPage = 1
-    private var totalPages = 0
     private var autoScrollJob: Job? = null
     private var scrollListener: androidx.recyclerview.widget.RecyclerView.OnScrollListener? = null
 
@@ -67,8 +60,7 @@ class HomeFragment : Fragment() {
     }
 
     private fun observeState() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        launchAndRepeatWithViewLifecycle {
                 homeViewModel.state.collect { state ->
                     if (_binding == null) return@collect
 
@@ -82,13 +74,11 @@ class HomeFragment : Fragment() {
 
                     filmAdapter.submitList(state.films)
                 }
-            }
         }
     }
 
     private fun observeEffect() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        launchAndRepeatWithViewLifecycle {
                 homeViewModel.effect.collect { effect ->
                     when (effect) {
                         is HomeUiEffect.ShowToast -> {
@@ -100,59 +90,41 @@ class HomeFragment : Fragment() {
                         }
                     }
                 }
-            }
         }
     }
 
     private fun setupRecyclerView() {
-        if (context?.isConnectedToInternet() == true) {
-            binding.recyclerView.apply {
-                val displayMetrics = resources.displayMetrics
-                var numberFilmInLine = (displayMetrics.widthPixels / 400).coerceIn(2, 5)
-                layoutManager = GridLayoutManager(requireContext(), ++numberFilmInLine)
-                adapter = filmAdapter
-            }
-
-            observeLatestFilms()
-
-            currentPage = 1
-            homeViewModel.getLatestFilms(currentPage)
-
-            scrollListener = object : androidx.recyclerview.widget.RecyclerView.OnScrollListener() {
-                override fun onScrolled(recyclerView: androidx.recyclerview.widget.RecyclerView, dx: Int, dy: Int) {
-                    if (_binding == null) return
-                    val layoutManager = recyclerView.layoutManager as GridLayoutManager
-                    if (currentPage < totalPages) {
-                        val lastVisibleItemPosition = layoutManager.findLastVisibleItemPosition()
-                        if (!isLoading && lastVisibleItemPosition >= layoutManager.itemCount - 1) {
-                            isLoading = true
-                            currentPage++
-                            homeViewModel.loadMoreLatestFilms(currentPage)
-                        }
-                    }
-                    val firstVisibleItemPosition = layoutManager.findFirstVisibleItemPosition()
-                    binding.scrollToTopButton.visibility =
-                        if (firstVisibleItemPosition > 0) View.VISIBLE else View.GONE
-                }
-            }
-            scrollListener?.let { binding.recyclerView.addOnScrollListener(it) }
-
-            binding.scrollToTopButton.setOnClickListener {
-                binding.recyclerView.smoothScrollToPosition(0)
-            }
-        } else {
+        val isConnected = homeViewModel.checkConnectivity(requireContext())
+        if (!isConnected) {
             Toast.makeText(context, getString(R.string.no_internet_retry), Toast.LENGTH_LONG).show()
+            return
         }
-    }
+        binding.recyclerView.apply {
+            val displayMetrics = resources.displayMetrics
+            var numberFilmInLine = (displayMetrics.widthPixels / 400).coerceIn(2, 5)
+            layoutManager = GridLayoutManager(requireContext(), ++numberFilmInLine)
+            adapter = filmAdapter
+        }
 
-    private fun observeLatestFilms() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                homeViewModel.state.collect { state ->
-                    totalPages = state.totalPages
-                    isLoading = state.isLoadingMore
+        homeViewModel.loadLatestFilms()
+
+        scrollListener = object : androidx.recyclerview.widget.RecyclerView.OnScrollListener() {
+            override fun onScrolled(recyclerView: androidx.recyclerview.widget.RecyclerView, dx: Int, dy: Int) {
+                if (_binding == null) return
+                val layoutManager = recyclerView.layoutManager as GridLayoutManager
+                val lastVisibleItemPosition = layoutManager.findLastVisibleItemPosition()
+                if (lastVisibleItemPosition >= layoutManager.itemCount - 1) {
+                    homeViewModel.onScrolledToBottom()
                 }
+                val firstVisibleItemPosition = layoutManager.findFirstVisibleItemPosition()
+                binding.scrollToTopButton.visibility =
+                    if (firstVisibleItemPosition > 0) View.VISIBLE else View.GONE
             }
+        }
+        scrollListener?.let { binding.recyclerView.addOnScrollListener(it) }
+
+        binding.scrollToTopButton.setOnClickListener {
+            binding.recyclerView.smoothScrollToPosition(0)
         }
     }
 
@@ -169,10 +141,5 @@ class HomeFragment : Fragment() {
         }
     }
 
-    private fun Context.isConnectedToInternet(): Boolean {
-        val connectivityManager = getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-        val network = connectivityManager.activeNetwork ?: return false
-        val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
-        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-    }
 }
+

--- a/app/src/main/java/com/drs/auralife/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/home/HomeViewModel.kt
@@ -1,5 +1,8 @@
 package com.drs.auralife.presentation.home
 
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -40,7 +43,8 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun getLatestFilms(page: Int) {
+    fun loadLatestFilms() {
+        val page = 1
         viewModelScope.launch {
             _state.value = _state.value.copy(isLoadingFilms = true, errorMessage = null)
             try {
@@ -48,6 +52,7 @@ class HomeViewModel @Inject constructor(
                 _state.value = _state.value.copy(
                     films = result.data,
                     totalPages = result.totalPages,
+                    currentPage = page,
                     isLoadingFilms = false,
                 )
             } catch (e: Exception) {
@@ -57,15 +62,19 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun loadMoreLatestFilms(page: Int) {
+    fun onScrolledToBottom() {
+        val current = _state.value
+        if (current.isLoadingMore || current.currentPage >= current.totalPages) return
+        val nextPage = current.currentPage + 1
         viewModelScope.launch {
             _state.value = _state.value.copy(isLoadingMore = true)
             try {
-                val result = getLatestFilmsUseCase(page)
+                val result = getLatestFilmsUseCase(nextPage)
                 val allFilms = _state.value.films + result.data
                 _state.value = _state.value.copy(
                     films = allFilms,
                     totalPages = result.totalPages,
+                    currentPage = nextPage,
                     isLoadingMore = false,
                 )
             } catch (e: Exception) {
@@ -80,5 +89,14 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             _effect.emit(HomeUiEffect.NavigateToFilm(slug))
         }
+    }
+
+    fun checkConnectivity(context: Context): Boolean {
+        val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val network = connectivityManager.activeNetwork ?: return false
+        val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
+        val connected = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        _state.value = _state.value.copy(isConnected = connected)
+        return connected
     }
 }

--- a/app/src/main/java/com/drs/auralife/presentation/home/adapter/BannerAdapter.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/home/adapter/BannerAdapter.kt
@@ -6,7 +6,7 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import androidx.recyclerview.widget.RecyclerView
 import com.drs.auralife.R
-import com.drs.auralife.core.utils.MyAppGlideModule
+import com.drs.auralife.presentation.common.MyAppGlideModule
 
 class BannerAdapter(
     private val banners: List<Pair<String, String>>,

--- a/app/src/main/java/com/drs/auralife/presentation/home/adapter/HomeFilmAdapter.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/home/adapter/HomeFilmAdapter.kt
@@ -9,7 +9,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.drs.auralife.R
-import com.drs.auralife.core.utils.MyAppGlideModule
+import com.drs.auralife.presentation.common.MyAppGlideModule
 import com.drs.auralife.domain.model.Film
 
 class HomeFilmAdapter(

--- a/app/src/main/java/com/drs/auralife/presentation/library/AddToLibraryDialog.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/library/AddToLibraryDialog.kt
@@ -46,8 +46,8 @@ object AddToLibraryDialog {
                                 LinearLayout.LayoutParams.MATCH_PARENT,
                                 LinearLayout.LayoutParams.WRAP_CONTENT,
                             ).apply {
-                                var dp5 = dpToPx(5f, resources.displayMetrics).toInt()
-                                var dp10 = dpToPx(10f, resources.displayMetrics).toInt()
+                                val dp5 = dpToPx(5f, resources.displayMetrics).toInt()
+                                val dp10 = dpToPx(10f, resources.displayMetrics).toInt()
                                 setMargins(dp5, 0, dp5, dp10)
                                 setBackgroundResource(R.drawable.rounded)
                                 isAllCaps = false

--- a/app/src/main/java/com/drs/auralife/presentation/library/LibraryFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/library/LibraryFragment.kt
@@ -10,7 +10,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import com.drs.auralife.presentation.util.launchAndRepeatWithViewLifecycle
+import com.drs.auralife.presentation.common.launchAndRepeatWithViewLifecycle
 import androidx.navigation.fragment.findNavController
 import com.drs.auralife.R
 import com.drs.auralife.databinding.FragmentLibraryBinding

--- a/app/src/main/java/com/drs/auralife/presentation/library/LibraryFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/library/LibraryFragment.kt
@@ -10,7 +10,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
+import com.drs.auralife.presentation.util.launchAndRepeatWithViewLifecycle
 import androidx.navigation.fragment.findNavController
 import com.drs.auralife.R
 import com.drs.auralife.databinding.FragmentLibraryBinding
@@ -40,15 +40,12 @@ class LibraryFragment : Fragment() {
         libraryAdapter = LibraryAdapter(
             onRename = { oldName, newName -> libraryViewModel.renameLibrary(oldName, newName) },
             onDelete = { name -> libraryViewModel.deleteLibrary(name) },
-            onItemClick = { name ->
-                val bundle = Bundle().apply { putString("name", name) }
-                findNavController().navigate(R.id.library_details, bundle)
-            },
+            onItemClick = { name -> libraryViewModel.onLibraryClicked(name) },
         )
         binding.recyclerView.adapter = libraryAdapter
 
         observeLibraries()
-        observeOperationResult()
+        observeEffect()
     }
 
     override fun onResume() {
@@ -62,8 +59,7 @@ class LibraryFragment : Fragment() {
     }
 
     private fun observeLibraries() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        launchAndRepeatWithViewLifecycle {
                 libraryViewModel.librariesState.collect { state ->
                     if (_binding == null) return@collect
                     libraryAdapter.submitList(state.libraries)
@@ -82,20 +78,22 @@ class LibraryFragment : Fragment() {
                         binding.text.text = state.errorMessage
                     }
                 }
-            }
         }
     }
 
-    private fun observeOperationResult() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                libraryViewModel.operationResult.collect { result ->
-                    result.onSuccess { refreshLibrary() }
-                        .onFailure { e ->
-                            Toast.makeText(requireContext(), e.message ?: getString(R.string.error), Toast.LENGTH_SHORT).show()
+    private fun observeEffect() {
+        launchAndRepeatWithViewLifecycle {
+                libraryViewModel.effect.collect { effect ->
+                    when (effect) {
+                        is LibraryUiEffect.ShowToast -> {
+                            Toast.makeText(requireContext(), effect.message, Toast.LENGTH_SHORT).show()
                         }
+                        is LibraryUiEffect.NavigateToDetails -> {
+                            val bundle = Bundle().apply { putString("name", effect.name) }
+                            findNavController().navigate(R.id.library_details, bundle)
+                        }
+                    }
                 }
-            }
         }
     }
 
@@ -103,3 +101,4 @@ class LibraryFragment : Fragment() {
         libraryViewModel.getLibraries()
     }
 }
+

--- a/app/src/main/java/com/drs/auralife/presentation/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/library/LibraryViewModel.kt
@@ -37,18 +37,14 @@ class LibraryViewModel @Inject constructor(
     private val _librariesState = MutableStateFlow(LibraryUiState())
     val librariesState: StateFlow<LibraryUiState> = _librariesState.asStateFlow()
 
-    private val _operationResult = MutableSharedFlow<Result<Boolean>>()
-    val operationResult: SharedFlow<Result<Boolean>> = _operationResult.asSharedFlow()
-
-    private val _librariesLoaded = MutableStateFlow<List<Library>>(emptyList())
-    val librariesLoaded: StateFlow<List<Library>> = _librariesLoaded.asStateFlow()
+    private val _effect = MutableSharedFlow<LibraryUiEffect>()
+    val effect: SharedFlow<LibraryUiEffect> = _effect.asSharedFlow()
 
     fun getLibraries() {
         viewModelScope.launch {
             _librariesState.value = _librariesState.value.copy(isLoading = true)
             try {
                 val libs = getLibraryUseCase()
-                _librariesLoaded.emit(libs)
                 _librariesState.value = _librariesState.value.copy(libraries = libs, isLoading = false)
             } catch (e: Exception) {
                 _librariesState.value = _librariesState.value.copy(isLoading = false, errorMessage = e.message)
@@ -64,7 +60,7 @@ class LibraryViewModel @Inject constructor(
                 films = listOf(LibraryFilm(slug = slug, currentEpisode = episodeCurrent)),
             )
             val result = addToLibraryUseCase(library)
-            _operationResult.emit(Result.success(result))
+            _effect.emit(LibraryUiEffect.ShowToast(if (result) "Added" else "Failed"))
         }
     }
 
@@ -76,17 +72,18 @@ class LibraryViewModel @Inject constructor(
                 films = listOf(LibraryFilm(slug = slug, currentEpisode = episodeCurrent)),
             )
             val result = createLibraryUseCase(library)
-            _operationResult.emit(Result.success(result))
+            _effect.emit(LibraryUiEffect.ShowToast(if (result) "Created" else "Failed"))
         }
     }
 
     fun renameLibrary(oldName: String, newName: String) {
         viewModelScope.launch {
             try {
-                val result = renameLibraryUseCase(oldName, newName)
-                _operationResult.emit(Result.success(result))
+                renameLibraryUseCase(oldName, newName)
+                getLibraries()
+                _effect.emit(LibraryUiEffect.ShowToast("Renamed"))
             } catch (e: Exception) {
-                _operationResult.emit(Result.failure(e))
+                _effect.emit(LibraryUiEffect.ShowToast(e.message ?: "Rename failed"))
             }
         }
     }
@@ -94,11 +91,18 @@ class LibraryViewModel @Inject constructor(
     fun deleteLibrary(name: String) {
         viewModelScope.launch {
             try {
-                val result = deleteLibraryUseCase(name)
-                _operationResult.emit(Result.success(result))
+                deleteLibraryUseCase(name)
+                getLibraries()
+                _effect.emit(LibraryUiEffect.ShowToast("Deleted"))
             } catch (e: Exception) {
-                _operationResult.emit(Result.failure(e))
+                _effect.emit(LibraryUiEffect.ShowToast(e.message ?: "Delete failed"))
             }
+        }
+    }
+
+    fun onLibraryClicked(name: String) {
+        viewModelScope.launch {
+            _effect.emit(LibraryUiEffect.NavigateToDetails(name))
         }
     }
 }

--- a/app/src/main/java/com/drs/auralife/presentation/library/adapter/LibraryAdapter.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/library/adapter/LibraryAdapter.kt
@@ -9,7 +9,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.drs.auralife.R
-import com.drs.auralife.core.utils.MyAppGlideModule
+import com.drs.auralife.presentation.common.MyAppGlideModule
 import com.drs.auralife.domain.model.Library
 import com.drs.auralife.presentation.library.EditLibraryDialog
 

--- a/app/src/main/java/com/drs/auralife/presentation/library_details/LibraryDetailsFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/library_details/LibraryDetailsFragment.kt
@@ -9,7 +9,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
+import com.drs.auralife.presentation.util.launchAndRepeatWithViewLifecycle
 import androidx.navigation.fragment.findNavController
 import com.drs.auralife.R
 import com.drs.auralife.databinding.ActivityLibraryDetailsBinding
@@ -23,14 +23,11 @@ class LibraryDetailsFragment : Fragment() {
 
     private val viewModel: LibraryDetailsViewModel by viewModels()
     private var _binding: ActivityLibraryDetailsBinding? = null
-    private val binding get() = _binding!!
+    private val binding get() = _binding ?: error("Binding accessed after onDestroyView")
     private var libraryName: String = ""
 
     private val filmAdapter = LibraryFilmAdapter(
-        onItemClick = { slug ->
-            val bundle = Bundle().apply { putString("slug", slug) }
-            findNavController().navigate(R.id.film_details, bundle)
-        },
+        onItemClick = { slug -> viewModel.onFilmClicked(slug) },
         onLongClick = { slug -> onLongClick(slug) },
     )
 
@@ -47,6 +44,7 @@ class LibraryDetailsFragment : Fragment() {
         binding.tvNameApp.text = "${binding.tvNameApp.text} - $libraryName"
 
         observeLibraryFilms()
+        observeEffect()
         viewModel.loadLibraryFilms(libraryName)
     }
 
@@ -56,8 +54,7 @@ class LibraryDetailsFragment : Fragment() {
     }
 
     private fun observeLibraryFilms() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        launchAndRepeatWithViewLifecycle {
                 viewModel.state.collect { state ->
                     if (state.films.isNotEmpty()) {
                         filmAdapter.submitList(state.films)
@@ -66,14 +63,29 @@ class LibraryDetailsFragment : Fragment() {
                         Toast.makeText(context, state.errorMessage, Toast.LENGTH_SHORT).show()
                     }
                 }
-            }
+        }
+    }
+
+    private fun observeEffect() {
+        launchAndRepeatWithViewLifecycle {
+                viewModel.effect.collect { effect ->
+                    when (effect) {
+                        is LibraryDetailUiEffect.ShowToast -> {
+                            Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
+                        }
+                        is LibraryDetailUiEffect.NavigateToFilm -> {
+                            val bundle = Bundle().apply { putString("slug", effect.slug) }
+                            findNavController().navigate(R.id.film_details, bundle)
+                        }
+                    }
+                }
         }
     }
 
     private fun onLongClick(slug: String) {
         EditLibraryDialog.showDeleteFilmFromLibrary(requireContext(), libraryName, slug) {
             viewModel.removeFilm(libraryName, slug)
-            viewModel.loadLibraryFilms(libraryName)
         }
     }
 }
+

--- a/app/src/main/java/com/drs/auralife/presentation/library_details/LibraryDetailsFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/library_details/LibraryDetailsFragment.kt
@@ -9,7 +9,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import com.drs.auralife.presentation.util.launchAndRepeatWithViewLifecycle
+import com.drs.auralife.presentation.common.launchAndRepeatWithViewLifecycle
 import androidx.navigation.fragment.findNavController
 import com.drs.auralife.R
 import com.drs.auralife.databinding.ActivityLibraryDetailsBinding

--- a/app/src/main/java/com/drs/auralife/presentation/library_details/LibraryDetailsViewModel.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/library_details/LibraryDetailsViewModel.kt
@@ -28,8 +28,8 @@ class LibraryDetailsViewModel @Inject constructor(
     private val _state = MutableStateFlow(LibraryDetailUiState())
     val state: StateFlow<LibraryDetailUiState> = _state.asStateFlow()
 
-    private val _operationResult = MutableSharedFlow<Result<Boolean>>()
-    val operationResult: SharedFlow<Result<Boolean>> = _operationResult.asSharedFlow()
+    private val _effect = MutableSharedFlow<LibraryDetailUiEffect>()
+    val effect: SharedFlow<LibraryDetailUiEffect> = _effect.asSharedFlow()
 
     fun loadLibraryFilms(name: String) {
         viewModelScope.launch {
@@ -66,11 +66,18 @@ class LibraryDetailsViewModel @Inject constructor(
     fun removeFilm(libraryName: String, slug: String) {
         viewModelScope.launch {
             try {
-                val result = removeFilmFromLibraryUseCase(libraryName, slug)
-                _operationResult.emit(Result.success(result))
+                removeFilmFromLibraryUseCase(libraryName, slug)
+                loadLibraryFilms(libraryName)
+                _effect.emit(LibraryDetailUiEffect.ShowToast("Removed from library"))
             } catch (e: Exception) {
-                _operationResult.emit(Result.failure(e))
+                _effect.emit(LibraryDetailUiEffect.ShowToast(e.message ?: "Remove failed"))
             }
+        }
+    }
+
+    fun onFilmClicked(slug: String) {
+        viewModelScope.launch {
+            _effect.emit(LibraryDetailUiEffect.NavigateToFilm(slug))
         }
     }
 }

--- a/app/src/main/java/com/drs/auralife/presentation/library_details/adapter/LibraryFilmAdapter.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/library_details/adapter/LibraryFilmAdapter.kt
@@ -9,7 +9,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.drs.auralife.R
-import com.drs.auralife.core.utils.MyAppGlideModule
+import com.drs.auralife.presentation.common.MyAppGlideModule
 import com.drs.auralife.domain.model.Film
 
 class LibraryFilmAdapter(

--- a/app/src/main/java/com/drs/auralife/presentation/login/LoginFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/login/LoginFragment.kt
@@ -11,7 +11,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
+import com.drs.auralife.presentation.util.launchAndRepeatWithViewLifecycle
 import androidx.navigation.fragment.findNavController
 import com.drs.auralife.R
 import com.drs.auralife.core.utils.Validator
@@ -24,7 +24,7 @@ import kotlinx.coroutines.launch
 class LoginFragment : Fragment() {
     private val loginViewModel: LoginViewModel by viewModels()
     private var _binding: ActivityLoginBinding? = null
-    private val binding get() = _binding!!
+    private val binding get() = _binding ?: error("Binding accessed after onDestroyView")
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = ActivityLoginBinding.inflate(inflater, container, false)
@@ -97,8 +97,7 @@ class LoginFragment : Fragment() {
     }
 
     private fun observeState() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        launchAndRepeatWithViewLifecycle {
                 loginViewModel.state.collect { state ->
                     when (state) {
                         is LoginUiState.Loading -> {
@@ -117,13 +116,11 @@ class LoginFragment : Fragment() {
                         else -> {}
                     }
                 }
-            }
         }
     }
 
     private fun observeEffect() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        launchAndRepeatWithViewLifecycle {
                 loginViewModel.effect.collect { effect ->
                     when (effect) {
                         is LoginUiEffect.ShowToast -> { /* snackbar if needed */ }
@@ -132,7 +129,7 @@ class LoginFragment : Fragment() {
                         }
                     }
                 }
-            }
         }
     }
 }
+

--- a/app/src/main/java/com/drs/auralife/presentation/login/LoginFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/login/LoginFragment.kt
@@ -11,10 +11,10 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import com.drs.auralife.presentation.util.launchAndRepeatWithViewLifecycle
+import com.drs.auralife.presentation.common.launchAndRepeatWithViewLifecycle
 import androidx.navigation.fragment.findNavController
 import com.drs.auralife.R
-import com.drs.auralife.core.utils.Validator
+import com.drs.auralife.core.validation.Validator
 import com.drs.auralife.databinding.ActivityLoginBinding
 import com.drs.auralife.presentation.common.LogoFragment
 import dagger.hilt.android.AndroidEntryPoint

--- a/app/src/main/java/com/drs/auralife/presentation/onboarding/OnboardingFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/onboarding/OnboardingFragment.kt
@@ -5,11 +5,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
-import androidx.core.content.edit
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
+import androidx.fragment.app.viewModels
+import com.drs.auralife.presentation.util.launchAndRepeatWithViewLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.viewpager2.widget.ViewPager2
 import com.drs.auralife.R
@@ -17,20 +15,14 @@ import com.drs.auralife.domain.model.OnboardingItem
 import com.drs.auralife.presentation.onboarding.adapter.OnboardingAdapter
 import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class OnboardingFragment : Fragment() {
 
+    private val onboardingViewModel: OnboardingViewModel by viewModels()
     private lateinit var onboardingAdapter: OnboardingAdapter
     private lateinit var onboardingViewPager: ViewPager2
     private lateinit var btnNext: Button
-
-    private val _effect = MutableSharedFlow<OnboardingUiEffect>()
-    private val effect: SharedFlow<OnboardingUiEffect> = _effect.asSharedFlow()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return inflater.inflate(R.layout.activity_onboarding, container, false)
@@ -52,8 +44,7 @@ class OnboardingFragment : Fragment() {
                 if (position == onboardingAdapter.itemCount - 1) {
                     btnNext.text = getString(R.string.start)
                     btnNext.setOnClickListener {
-                        requireActivity().getSharedPreferences("PREFERENCE", 0).edit { putBoolean("isFirstTime", false) }
-                        findNavController().navigate(R.id.action_onboarding_to_home)
+                        onboardingViewModel.finishOnboarding()
                     }
                 } else {
                     btnNext.text = getString(R.string.next)
@@ -77,17 +68,14 @@ class OnboardingFragment : Fragment() {
     }
 
     private fun observeEffect() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                effect.collect { effect ->
+        launchAndRepeatWithViewLifecycle {
+                onboardingViewModel.effect.collect { effect ->
                     when (effect) {
                         is OnboardingUiEffect.NavigateToMain -> {
-                            requireActivity().getSharedPreferences("PREFERENCE", 0).edit { putBoolean("isFirstTime", false) }
                             findNavController().navigate(R.id.action_onboarding_to_home)
                         }
                     }
                 }
-            }
         }
     }
 }

--- a/app/src/main/java/com/drs/auralife/presentation/onboarding/OnboardingFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/onboarding/OnboardingFragment.kt
@@ -7,7 +7,7 @@ import android.view.ViewGroup
 import android.widget.Button
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import com.drs.auralife.presentation.util.launchAndRepeatWithViewLifecycle
+import com.drs.auralife.presentation.common.launchAndRepeatWithViewLifecycle
 import androidx.navigation.fragment.findNavController
 import androidx.viewpager2.widget.ViewPager2
 import com.drs.auralife.R

--- a/app/src/main/java/com/drs/auralife/presentation/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/onboarding/OnboardingViewModel.kt
@@ -1,0 +1,28 @@
+package com.drs.auralife.presentation.onboarding
+
+import android.app.Application
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.core.content.edit
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class OnboardingViewModel @Inject constructor(
+    private val application: Application,
+) : ViewModel() {
+
+    private val _effect = MutableSharedFlow<OnboardingUiEffect>()
+    val effect: SharedFlow<OnboardingUiEffect> = _effect.asSharedFlow()
+
+    fun finishOnboarding() {
+        viewModelScope.launch {
+            application.getSharedPreferences("PREFERENCE", 0).edit { putBoolean("isFirstTime", false) }
+            _effect.emit(OnboardingUiEffect.NavigateToMain)
+        }
+    }
+}

--- a/app/src/main/java/com/drs/auralife/presentation/payment/PaymentFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/payment/PaymentFragment.kt
@@ -14,7 +14,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
+import com.drs.auralife.presentation.util.launchAndRepeatWithViewLifecycle
 import com.drs.auralife.R
 import com.drs.auralife.databinding.ActivityPaymentBinding
 import com.drs.auralife.domain.model.PaymentItem
@@ -31,7 +31,7 @@ class PaymentFragment : Fragment() {
 
     private val premiumViewModel: PremiumViewModel by viewModels()
     private var _binding: ActivityPaymentBinding? = null
-    private val binding get() = _binding!!
+    private val binding get() = _binding ?: error("Binding accessed after onDestroyView")
     private lateinit var paymentAdapter: PaymentAdapter
 
     @SuppressLint("InflateParams")
@@ -74,8 +74,7 @@ class PaymentFragment : Fragment() {
     }
 
     private fun observePremiumStatus() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        launchAndRepeatWithViewLifecycle {
                 premiumViewModel.state.collect { state ->
                     val status = state.premiumStatus ?: return@collect
                     binding.apply {
@@ -95,22 +94,21 @@ class PaymentFragment : Fragment() {
                         }
                     }
                 }
-            }
         }
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                premiumViewModel.purchaseResult.collect { result ->
-                    result.onSuccess { success ->
-                        Toast.makeText(
-                            context,
-                            if (success) R.string.purchase_success else R.string.payment_unavailable,
-                            Toast.LENGTH_SHORT,
-                        ).show()
-                    }.onFailure {
-                        Toast.makeText(context, R.string.payment_unavailable, Toast.LENGTH_LONG).show()
+        launchAndRepeatWithViewLifecycle {
+                premiumViewModel.effect.collect { effect ->
+                    when (effect) {
+                        is PaymentUiEffect.ShowToast -> {
+                            Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
+                        }
+                        is PaymentUiEffect.PurchaseSuccess -> {
+                            Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
+                        }
+                        is PaymentUiEffect.PurchaseError -> {
+                            Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
+                        }
                     }
                 }
-            }
         }
     }
 
@@ -124,3 +122,4 @@ class PaymentFragment : Fragment() {
         binding.rvPayment.adapter = paymentAdapter
     }
 }
+

--- a/app/src/main/java/com/drs/auralife/presentation/payment/PaymentFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/payment/PaymentFragment.kt
@@ -14,7 +14,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import com.drs.auralife.presentation.util.launchAndRepeatWithViewLifecycle
+import com.drs.auralife.presentation.common.launchAndRepeatWithViewLifecycle
 import com.drs.auralife.R
 import com.drs.auralife.databinding.ActivityPaymentBinding
 import com.drs.auralife.domain.model.PaymentItem

--- a/app/src/main/java/com/drs/auralife/presentation/playfilm/PlayFilmFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/playfilm/PlayFilmFragment.kt
@@ -14,7 +14,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
+import com.drs.auralife.presentation.util.launchAndRepeatWithViewLifecycle
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
@@ -133,8 +133,7 @@ class PlayFilmFragment : Fragment() {
     }
 
     private fun observeFilmDetails() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        launchAndRepeatWithViewLifecycle {
                 filmDetailsViewModel.state.collect { state ->
                     if (state.film != null) {
                         film = state.film
@@ -145,15 +144,13 @@ class PlayFilmFragment : Fragment() {
                             }
                     }
                 }
-            }
         }
 
         playFilmViewModel.loadPremiumStatus()
     }
 
     private fun observeEffect() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        launchAndRepeatWithViewLifecycle {
                 playFilmViewModel.effect.collect { effect ->
                     when (effect) {
                         is PlayFilmUiEffect.ShowPremiumDialog -> {
@@ -170,7 +167,6 @@ class PlayFilmFragment : Fragment() {
                         }
                     }
                 }
-            }
         }
     }
 
@@ -256,8 +252,7 @@ class PlayFilmFragment : Fragment() {
     }
 
     private fun startPlaybackMonitor() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
+        launchAndRepeatWithViewLifecycle {
                 while (true) {
                     exoPlayer?.let { player ->
                         playFilmViewModel.checkPlaybackThrottle(
@@ -267,7 +262,6 @@ class PlayFilmFragment : Fragment() {
                     }
                     delay(1000)
                 }
-            }
         }
     }
 
@@ -291,3 +285,4 @@ class PlayFilmFragment : Fragment() {
         dialog.show()
     }
 }
+

--- a/app/src/main/java/com/drs/auralife/presentation/playfilm/PlayFilmFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/playfilm/PlayFilmFragment.kt
@@ -14,7 +14,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import com.drs.auralife.presentation.util.launchAndRepeatWithViewLifecycle
+import com.drs.auralife.presentation.common.launchAndRepeatWithViewLifecycle
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
@@ -26,7 +26,7 @@ import com.drs.auralife.domain.model.FilmDetails
 import com.drs.auralife.presentation.filmdetails.FilmDetailsViewModel
 import com.drs.auralife.presentation.history.HistoryViewModel
 import com.drs.auralife.presentation.playfilm.adapter.EpisodeAdapter
-import com.drs.auralife.core.utils.SystemUiController
+import com.drs.auralife.presentation.common.SystemUiController
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/drs/auralife/presentation/register/RegisterFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/register/RegisterFragment.kt
@@ -9,7 +9,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
+import com.drs.auralife.presentation.util.launchAndRepeatWithViewLifecycle
 import androidx.navigation.fragment.findNavController
 import com.drs.auralife.R
 import com.drs.auralife.core.utils.Validator
@@ -22,7 +22,7 @@ import kotlinx.coroutines.launch
 class RegisterFragment : Fragment() {
     private val registerViewModel: RegisterViewModel by viewModels()
     private var _binding: ActivityRegisterBinding? = null
-    private val binding get() = _binding!!
+    private val binding get() = _binding ?: error("Binding accessed after onDestroyView")
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = ActivityRegisterBinding.inflate(inflater, container, false)
@@ -93,8 +93,7 @@ class RegisterFragment : Fragment() {
     }
 
     private fun observeState() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        launchAndRepeatWithViewLifecycle {
                 registerViewModel.state.collect { state ->
                     when (state) {
                         is RegisterUiState.Loading -> {
@@ -113,13 +112,11 @@ class RegisterFragment : Fragment() {
                         else -> {}
                     }
                 }
-            }
         }
     }
 
     private fun observeEffect() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        launchAndRepeatWithViewLifecycle {
                 registerViewModel.effect.collect { effect ->
                     when (effect) {
                         is RegisterUiEffect.ShowToast -> { /* snackbar if needed */ }
@@ -128,7 +125,7 @@ class RegisterFragment : Fragment() {
                         }
                     }
                 }
-            }
         }
     }
 }
+

--- a/app/src/main/java/com/drs/auralife/presentation/register/RegisterFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/register/RegisterFragment.kt
@@ -9,10 +9,10 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import com.drs.auralife.presentation.util.launchAndRepeatWithViewLifecycle
+import com.drs.auralife.presentation.common.launchAndRepeatWithViewLifecycle
 import androidx.navigation.fragment.findNavController
 import com.drs.auralife.R
-import com.drs.auralife.core.utils.Validator
+import com.drs.auralife.core.validation.Validator
 import com.drs.auralife.databinding.ActivityRegisterBinding
 import com.drs.auralife.presentation.common.LogoFragment
 import dagger.hilt.android.AndroidEntryPoint

--- a/app/src/main/java/com/drs/auralife/presentation/search/SearchFilmAdapter.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/search/SearchFilmAdapter.kt
@@ -10,7 +10,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.drs.auralife.R
 import com.drs.auralife.domain.model.Film
-import com.drs.auralife.core.utils.MyAppGlideModule
+import com.drs.auralife.presentation.common.MyAppGlideModule
 
 class SearchFilmAdapter(
     private val onItemClick: (String) -> Unit,

--- a/app/src/main/java/com/drs/auralife/presentation/splash/SplashFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/splash/SplashFragment.kt
@@ -6,24 +6,17 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
+import androidx.fragment.app.viewModels
+import com.drs.auralife.presentation.util.launchAndRepeatWithViewLifecycle
 import androidx.navigation.fragment.findNavController
 import com.drs.auralife.R
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 @SuppressLint("CustomSplashScreen")
 class SplashFragment : Fragment() {
 
-    private val _effect = MutableSharedFlow<SplashUiEffect>()
-    private val effect: SharedFlow<SplashUiEffect> = _effect.asSharedFlow()
+    private val splashViewModel: SplashViewModel by viewModels()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return inflater.inflate(R.layout.activity_splash_screen, container, false)
@@ -32,28 +25,12 @@ class SplashFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         observeEffect()
-        startSplash()
-    }
-
-    private fun startSplash() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            val isFirstTime = requireActivity()
-                .getSharedPreferences("PREFERENCE", 0)
-                .getBoolean("isFirstTime", true)
-
-            val delayMs = if (isFirstTime) 3000L else 1000L
-            delay(delayMs)
-            _effect.emit(
-                if (isFirstTime) SplashUiEffect.NavigateToOnboarding
-                else SplashUiEffect.NavigateToHome
-            )
-        }
+        splashViewModel.start()
     }
 
     private fun observeEffect() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                effect.collect { effect ->
+        launchAndRepeatWithViewLifecycle {
+                splashViewModel.effect.collect { effect ->
                     when (effect) {
                         is SplashUiEffect.NavigateToOnboarding -> {
                             findNavController().navigate(R.id.action_splash_to_onboarding)
@@ -63,7 +40,6 @@ class SplashFragment : Fragment() {
                         }
                     }
                 }
-            }
         }
     }
 }

--- a/app/src/main/java/com/drs/auralife/presentation/splash/SplashFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/splash/SplashFragment.kt
@@ -7,7 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import com.drs.auralife.presentation.util.launchAndRepeatWithViewLifecycle
+import com.drs.auralife.presentation.common.launchAndRepeatWithViewLifecycle
 import androidx.navigation.fragment.findNavController
 import com.drs.auralife.R
 import dagger.hilt.android.AndroidEntryPoint

--- a/app/src/main/java/com/drs/auralife/presentation/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/splash/SplashViewModel.kt
@@ -1,0 +1,34 @@
+package com.drs.auralife.presentation.splash
+
+import android.app.Application
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SplashViewModel @Inject constructor(
+    private val application: Application,
+) : ViewModel() {
+
+    private val _effect = MutableSharedFlow<SplashUiEffect>()
+    val effect: SharedFlow<SplashUiEffect> = _effect.asSharedFlow()
+
+    fun start() {
+        viewModelScope.launch {
+            val prefs = application.getSharedPreferences("PREFERENCE", 0)
+            val isFirstTime = prefs.getBoolean("isFirstTime", true)
+            val delayMs = if (isFirstTime) 3000L else 1000L
+            delay(delayMs)
+            _effect.emit(
+                if (isFirstTime) SplashUiEffect.NavigateToOnboarding
+                else SplashUiEffect.NavigateToHome
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/drs/auralife/presentation/util/UiUtils.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/util/UiUtils.kt
@@ -1,0 +1,19 @@
+package com.drs.auralife.presentation.util
+
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+inline fun Fragment.launchAndRepeatWithViewLifecycle(
+    minActiveState: Lifecycle.State = Lifecycle.State.STARTED,
+    crossinline block: suspend CoroutineScope.() -> Unit
+) {
+    viewLifecycleOwner.lifecycleScope.launch {
+        viewLifecycleOwner.lifecycle.repeatOnLifecycle(minActiveState) {
+            block()
+        }
+    }
+}


### PR DESCRIPTION
### Changes
- launchAndRepeatWithViewLifecycle util + migrate all 13 fragments
- Pagination → ViewModel UiState (Home, ExploreDetails)
- Library/Payment: effect SharedFlow thay thế operationResult/purchaseResult
- Splash/Onboarding: @HiltViewModel
- Binding safety pattern
- Package restructure: core/utils/ → core/{validation,worker,util}/, presentation/{util→common}/
- UiState.kt (unused) removed