### PR TITLE
feat: extract search into standalone fragment

### DIFF
--- a/app/src/main/java/com/drs/auralife/presentation/MainActivity.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/MainActivity.kt
@@ -6,7 +6,6 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
-import android.widget.EditText
 import android.widget.FrameLayout
 import android.widget.ImageButton
 import android.widget.ImageView
@@ -41,24 +40,13 @@ import com.drs.auralife.core.util.Notification
 import com.drs.auralife.presentation.common.PermissionPhotoHandler
 import com.drs.auralife.core.worker.UpdateLibraryWorker
 import com.drs.auralife.presentation.common.NotificationAdapter
-import com.drs.auralife.presentation.navigation.NavRoutes
-import com.drs.auralife.presentation.search.SearchFilmAdapter
-import com.drs.auralife.presentation.search.SearchUiEffect
-import com.drs.auralife.presentation.search.SearchUiState
-import com.drs.auralife.presentation.search.SearchViewModel
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.navigation.NavigationView
-import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.util.concurrent.TimeUnit
 
     @dagger.hilt.android.AndroidEntryPoint
-@OptIn(FlowPreview::class)
 class MainActivity : AppCompatActivity(), AppBarProvider {
     companion object {
         private const val PREF_NAME = "PREFERENCE"
@@ -74,13 +62,6 @@ class MainActivity : AppCompatActivity(), AppBarProvider {
     private var pageChangeCallback: androidx.viewpager2.widget.ViewPager2.OnPageChangeCallback? = null
 
     private val mainViewModel: MainViewModel by viewModels()
-    private val searchViewModel: SearchViewModel by viewModels()
-
-    private var searchBar: EditText? = null
-    private var searchLayout: LinearLayout? = null
-    private var searchResults: RecyclerView? = null
-    private var searchAdapter: SearchFilmAdapter? = null
-    private val searchQueryFlow = kotlinx.coroutines.flow.MutableStateFlow("")
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -93,15 +74,11 @@ class MainActivity : AppCompatActivity(), AppBarProvider {
         drawerLayout = findViewById(R.id.main_layout)
         navigationView = findViewById(R.id.navigation_view)
         bottomNavigationView = findViewById(R.id.bottom_navigation_view)
-        searchLayout = findViewById(R.id.search_layout)
-        searchBar = findViewById(R.id.search_bar)
-        searchResults = findViewById(R.id.search_results)
 
         setupBottomNav()
         setupDrawer()
         setupBackPressed()
         hideBottomNavOnDetailScreens()
-        setupSearch()
     }
 
     override fun onPostCreate(savedInstanceState: Bundle?) {
@@ -272,10 +249,6 @@ class MainActivity : AppCompatActivity(), AppBarProvider {
     private fun setupBackPressed() {
         val onBackPressedCallback = object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
-                if (searchLayout?.visibility == View.VISIBLE) {
-                    hideSearch()
-                    return
-                }
                 if (!navController.popBackStack()) {
                     finish()
                 }
@@ -289,6 +262,7 @@ class MainActivity : AppCompatActivity(), AppBarProvider {
             val detailDestinations = setOf(
                 R.id.film_details, R.id.library_details, R.id.payment,
                 R.id.play_film, R.id.explore_details, R.id.login, R.id.register,
+                R.id.search,
             )
             bottomNavigationView.visibility =
                 if (destination.id in detailDestinations) View.GONE else View.VISIBLE
@@ -319,96 +293,12 @@ class MainActivity : AppCompatActivity(), AppBarProvider {
         }
 
         appBarSearch.setOnClickListener {
-            showSearch()
+            navController.navigate(R.id.search)
         }
 
         appBarNotifications.setOnClickListener {
             showNotificationList(it)
         }
-    }
-
-    private fun setupSearch() {
-        searchAdapter = SearchFilmAdapter { slug ->
-            hideSearch()
-            val bundle = Bundle().apply { putString("slug", slug) }
-            navController.navigate(R.id.film_details, bundle)
-        }
-        searchResults?.layoutManager = LinearLayoutManager(this)
-        searchResults?.adapter = searchAdapter
-
-        val textWatcher = object : android.text.TextWatcher {
-            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
-            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
-            override fun afterTextChanged(s: android.text.Editable?) {
-                searchQueryFlow.value = s.toString().trim()
-                if (s.toString().trim().isEmpty()) {
-                    searchViewModel.clearResults()
-                    searchAdapter?.replaceItems(emptyList())
-                }
-            }
-        }
-        searchBar?.addTextChangedListener(textWatcher)
-
-        observeSearchState()
-        observeSearchEffect()
-
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                searchQueryFlow
-                    .debounce(500)
-                    .distinctUntilChanged()
-                    .filter { it.isNotEmpty() }
-                    .collectLatest { query ->
-                        searchViewModel.searchFilms(query, 5)
-                    }
-            }
-        }
-    }
-
-    private fun observeSearchState() {
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                searchViewModel.state.collect { state ->
-                    when (state) {
-                        is SearchUiState.Success -> {
-                            searchAdapter?.replaceItems(state.films)
-                        }
-                        else -> { /* idle, loading, error handled implicitly */ }
-                    }
-                }
-            }
-        }
-    }
-
-    private fun observeSearchEffect() {
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                searchViewModel.effect.collect { effect ->
-                    when (effect) {
-                        is SearchUiEffect.NavigateToFilmDetails -> {
-                            hideSearch()
-                            val bundle = Bundle().apply { putString("slug", effect.slug) }
-                            navController.navigate(R.id.film_details, bundle)
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    private fun showSearch() {
-        searchLayout?.visibility = View.VISIBLE
-        bottomNavigationView.visibility = View.GONE
-        searchBar?.requestFocus()
-        searchResults?.adapter = searchAdapter
-    }
-
-    private fun hideSearch() {
-        searchLayout?.visibility = View.GONE
-        bottomNavigationView.visibility = View.VISIBLE
-        searchBar?.text?.clear()
-        searchViewModel.clearResults()
-        searchAdapter?.replaceItems(emptyList())
     }
 
     @SuppressLint("InflateParams")

--- a/app/src/main/java/com/drs/auralife/presentation/search/SearchFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/search/SearchFragment.kt
@@ -1,0 +1,116 @@
+package com.drs.auralife.presentation.search
+
+import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.NavOptions
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.drs.auralife.R
+import com.drs.auralife.databinding.FragmentSearchBinding
+import com.drs.auralife.presentation.common.launchAndRepeatWithViewLifecycle
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.launch
+
+@OptIn(FlowPreview::class)
+@AndroidEntryPoint
+class SearchFragment : Fragment() {
+
+    private var _binding: FragmentSearchBinding? = null
+    private val binding get() = _binding ?: error("Binding accessed after onDestroyView")
+
+    private val searchViewModel: SearchViewModel by viewModels()
+    private val searchQueryFlow = MutableStateFlow("")
+    private var searchAdapter: SearchFilmAdapter? = null
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentSearchBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupSearch()
+        binding.searchBar.requestFocus()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun setupSearch() {
+        searchAdapter = SearchFilmAdapter { slug ->
+            val bundle = Bundle().apply { putString("slug", slug) }
+            val navOptions = NavOptions.Builder()
+                .setPopUpTo(R.id.search, true)
+                .build()
+            findNavController().navigate(R.id.film_details, bundle, navOptions)
+        }
+        binding.searchResults.layoutManager = LinearLayoutManager(requireContext())
+        binding.searchResults.adapter = searchAdapter
+
+        binding.searchBar.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+            override fun afterTextChanged(s: Editable?) {
+                searchQueryFlow.value = s.toString().trim()
+                if (s.toString().trim().isEmpty()) {
+                    searchViewModel.clearResults()
+                    searchAdapter?.replaceItems(emptyList())
+                }
+            }
+        })
+
+        launchAndRepeatWithViewLifecycle {
+            searchViewModel.state.collect { state ->
+                when (state) {
+                    is SearchUiState.Success -> {
+                        searchAdapter?.replaceItems(state.films)
+                    }
+                    else -> {}
+                }
+            }
+        }
+
+        launchAndRepeatWithViewLifecycle {
+            searchViewModel.effect.collect { effect ->
+                when (effect) {
+                    is SearchUiEffect.NavigateToFilmDetails -> {
+                        val bundle = Bundle().apply { putString("slug", effect.slug) }
+                        val navOptions = NavOptions.Builder()
+                            .setPopUpTo(R.id.search, true)
+                            .build()
+                        findNavController().navigate(R.id.film_details, bundle, navOptions)
+                    }
+                }
+            }
+        }
+
+        lifecycleScope.launch {
+            searchQueryFlow
+                .debounce(500)
+                .distinctUntilChanged()
+                .filter { it.isNotEmpty() }
+                .collectLatest { query ->
+                    searchViewModel.searchFilms(query, 5)
+                }
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -37,30 +37,4 @@
         app:headerLayout="@layout/nav_header"
         app:menu="@menu/drawer_nav_menu" />
 
-    <LinearLayout
-        android:id="@+id/search_layout"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@color/transparent"
-        android:gravity="top"
-        android:orientation="vertical"
-        android:visibility="gone">
-
-        <EditText
-            android:id="@+id/search_bar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="10dp"
-            android:background="@drawable/rounded"
-            android:hint="@string/enter_search_keywords"
-            android:padding="10dp"
-            android:singleLine="true"
-            tools:ignore="Autofill,TextFields" />
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/search_results"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_margin="10dp" />
-    </LinearLayout>
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/white"
+    android:gravity="top"
+    android:orientation="vertical">
+
+    <EditText
+        android:id="@+id/search_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="10dp"
+        android:background="@drawable/rounded"
+        android:hint="@string/enter_search_keywords"
+        android:padding="10dp"
+        android:singleLine="true"
+        tools:ignore="Autofill,TextFields" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/search_results"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="10dp" />
+</LinearLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -119,6 +119,11 @@
     </fragment>
 
     <fragment
+        android:id="@+id/search"
+        android:name="com.drs.auralife.presentation.search.SearchFragment"
+        android:label="Search" />
+
+    <fragment
         android:id="@+id/explore_details"
         android:name="com.drs.auralife.presentation.explore_details.ExploreDetailsFragment"
         android:label="ExploreDetails"


### PR DESCRIPTION
### Changes
- Create \SearchFragment\ with own layout (\ragment_search.xml\) and search logic
- Add \search\ destination to \
av_graph.xml\
- Move search bar, RecyclerView, TextWatcher, debounced query, state/effect observation from \MainActivity\ to \SearchFragment\
- Remove search overlay views (\search_layout\, \search_bar\, \search_results\) from \ctivity_main.xml\
- Search now pops itself from back stack when navigating to film details via \NavOptions.popUpTo\
- \MainActivity\ delegates to nav instead of show/hide inline

### Backward compatibility
Search flow unchanged: app_bar_search → navigate to search → type → tap result → film_details