### PR TITLE
refactor: replace all action navigations with NavRoutes

### DIFF
--- a/app/src/main/java/com/drs/auralife/presentation/filmdetails/FilmDetailsFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/filmdetails/FilmDetailsFragment.kt
@@ -18,6 +18,7 @@ import com.drs.auralife.presentation.common.launchAndRepeatWithViewLifecycle
 import androidx.navigation.fragment.findNavController
 import com.drs.auralife.R
 import com.drs.auralife.presentation.common.MyAppGlideModule
+import com.drs.auralife.presentation.navigation.NavRoutes
 import com.drs.auralife.databinding.ActivityFilmDetailsBinding
 import com.drs.auralife.presentation.library.AddToLibraryDialog
 import com.drs.auralife.presentation.library.LibraryUiEffect
@@ -78,11 +79,10 @@ class FilmDetailsFragment : Fragment() {
                             Toast.makeText(context, effect.message, Toast.LENGTH_SHORT).show()
                         }
                         is FilmDetailsUiEffect.NavigateToPlayFilm -> {
-                            val bundle = Bundle().apply { putString("slug", effect.slug) }
-                            findNavController().navigate(R.id.action_film_details_to_play_film, bundle)
+                            findNavController().navigate(NavRoutes.playFilm(effect.slug))
                         }
                         is FilmDetailsUiEffect.NavigateToLogin -> {
-                            findNavController().navigate(R.id.action_film_details_to_login)
+                            findNavController().navigate(NavRoutes.LOGIN)
                         }
                     }
                 }

--- a/app/src/main/java/com/drs/auralife/presentation/navigation/NavRoutes.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/navigation/NavRoutes.kt
@@ -10,11 +10,7 @@ object NavRoutes {
     const val EXPLORE = "explore"
     const val LIBRARY = "library"
     const val HISTORY = "history"
-    const val FILM_DETAILS = "film_details/{slug}"
-    const val LIBRARY_DETAILS = "library_details/{name}"
     const val PAYMENT = "payment"
-    const val PLAY_FILM = "play_film/{slug}"
-    const val EXPLORE_DETAILS = "explore_details/{slug}/{name}"
     const val SEARCH = "search"
 
     fun filmDetails(slug: String) = "film_details/$slug"

--- a/app/src/main/java/com/drs/auralife/presentation/onboarding/OnboardingFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/onboarding/OnboardingFragment.kt
@@ -8,10 +8,12 @@ import android.widget.Button
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.drs.auralife.presentation.common.launchAndRepeatWithViewLifecycle
+import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
 import androidx.viewpager2.widget.ViewPager2
 import com.drs.auralife.R
 import com.drs.auralife.domain.model.OnboardingItem
+import com.drs.auralife.presentation.navigation.NavRoutes
 import com.drs.auralife.presentation.onboarding.adapter.OnboardingAdapter
 import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
@@ -72,7 +74,10 @@ class OnboardingFragment : Fragment() {
                 onboardingViewModel.effect.collect { effect ->
                     when (effect) {
                         is OnboardingUiEffect.NavigateToMain -> {
-                            findNavController().navigate(R.id.action_onboarding_to_home)
+                            findNavController().navigate(
+                                NavRoutes.HOME,
+                                NavOptions.Builder().setPopUpTo(R.id.splash, true).build(),
+                            )
                         }
                     }
                 }

--- a/app/src/main/java/com/drs/auralife/presentation/playfilm/PlayFilmFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/playfilm/PlayFilmFragment.kt
@@ -23,6 +23,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.GridLayoutManager
 import com.drs.auralife.R
 import com.drs.auralife.domain.model.FilmDetails
+import com.drs.auralife.presentation.navigation.NavRoutes
 import com.drs.auralife.presentation.filmdetails.FilmDetailsViewModel
 import com.drs.auralife.presentation.history.HistoryViewModel
 import com.drs.auralife.presentation.playfilm.adapter.EpisodeAdapter
@@ -160,10 +161,10 @@ class PlayFilmFragment : Fragment() {
                             showPremiumDialog()
                         }
                         is PlayFilmUiEffect.NavigateToPayment -> {
-                            findNavController().navigate(R.id.action_play_film_to_payment)
+                            findNavController().navigate(NavRoutes.PAYMENT)
                         }
                         is PlayFilmUiEffect.NavigateToLogin -> {
-                            findNavController().navigate(R.id.action_play_film_to_login)
+                            findNavController().navigate(NavRoutes.LOGIN)
                         }
                     }
                 }

--- a/app/src/main/java/com/drs/auralife/presentation/splash/SplashFragment.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/splash/SplashFragment.kt
@@ -8,8 +8,10 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.drs.auralife.presentation.common.launchAndRepeatWithViewLifecycle
+import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
 import com.drs.auralife.R
+import com.drs.auralife.presentation.navigation.NavRoutes
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -33,10 +35,16 @@ class SplashFragment : Fragment() {
                 splashViewModel.effect.collect { effect ->
                     when (effect) {
                         is SplashUiEffect.NavigateToOnboarding -> {
-                            findNavController().navigate(R.id.action_splash_to_onboarding)
+                            findNavController().navigate(
+                                NavRoutes.ONBOARDING,
+                                NavOptions.Builder().setPopUpTo(R.id.splash, true).build(),
+                            )
                         }
                         is SplashUiEffect.NavigateToHome -> {
-                            findNavController().navigate(R.id.action_splash_to_home)
+                            findNavController().navigate(
+                                NavRoutes.HOME,
+                                NavOptions.Builder().setPopUpTo(R.id.splash, true).build(),
+                            )
                         }
                     }
                 }

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -11,16 +11,6 @@
         android:label="Splash"
         app:route="splash"
         tools:layout="@layout/activity_splash_screen">
-        <action
-            android:id="@+id/action_splash_to_onboarding"
-            app:destination="@id/onboarding"
-            app:popUpTo="@id/splash"
-            app:popUpToInclusive="true" />
-        <action
-            android:id="@+id/action_splash_to_home"
-            app:destination="@id/home"
-            app:popUpTo="@id/splash"
-            app:popUpToInclusive="true" />
     </fragment>
 
     <fragment
@@ -29,11 +19,6 @@
         android:label="Onboarding"
         app:route="onboarding"
         tools:layout="@layout/activity_onboarding">
-        <action
-            android:id="@+id/action_onboarding_to_home"
-            app:destination="@id/home"
-            app:popUpTo="@id/splash"
-            app:popUpToInclusive="true" />
     </fragment>
 
     <fragment
@@ -87,12 +72,6 @@
         <argument
             android:name="slug"
             app:argType="string" />
-        <action
-            android:id="@+id/action_film_details_to_play_film"
-            app:destination="@id/play_film" />
-        <action
-            android:id="@+id/action_film_details_to_login"
-            app:destination="@id/login" />
     </fragment>
 
     <fragment
@@ -122,12 +101,6 @@
         <argument
             android:name="slug"
             app:argType="string" />
-        <action
-            android:id="@+id/action_play_film_to_payment"
-            app:destination="@id/payment" />
-        <action
-            android:id="@+id/action_play_film_to_login"
-            app:destination="@id/login" />
     </fragment>
 
     <fragment


### PR DESCRIPTION

- Replace \R.id.action_*\ and \Bundle\ calls in SplashFragment, OnboardingFragment, FilmDetailsFragment, PlayFilmFragment with \NavRoutes.xxx()\ 
- Add \NavOptions.Builder().setPopUpTo(R.id.splash, true)\ for splash→onboarding/home and onboarding→home (popUpTo behavior preserved)
- Remove all 7 actions from \
av_graph.xml\ (\action_splash_to_*\, \action_onboarding_to_*\, \action_film_details_to_*\, \action_play_film_to_*\)
- Remove unused \const val\ with \{slug}\/\{name}\ placeholders from \NavRoutes.kt\ (FILM_DETAILS, LIBRARY_DETAILS, PLAY_FILM, EXPLORE_DETAILS)
- NavRoutes is now the single source of truth for all navigation