### PR TITLE
fix: remove broad media permissions per Google Play policy

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,8 +4,6 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"

--- a/app/src/main/java/com/drs/auralife/presentation/common/PermissionPhotoHandler.kt
+++ b/app/src/main/java/com/drs/auralife/presentation/common/PermissionPhotoHandler.kt
@@ -12,20 +12,13 @@ class PermissionPhotoHandler(
     private val activity: Activity,
     private val activityResultLauncher: ActivityResultLauncher<Intent>,
 ) {
-    private val permissions = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        arrayOf(
-            Manifest.permission.READ_MEDIA_IMAGES,
-            Manifest.permission.READ_MEDIA_VIDEO,
-        )
-    } else {
-        arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
-    }
-
     fun checkAndRequestPermissions() {
-        if (permissions.all { ActivityCompat.checkSelfPermission(activity, it) == PackageManager.PERMISSION_GRANTED }) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            pickImageFromGallery()
+        } else if (ActivityCompat.checkSelfPermission(activity, Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
             pickImageFromGallery()
         } else {
-            ActivityCompat.requestPermissions(activity, permissions, REQUEST_CODE_PERMISSIONS)
+            ActivityCompat.requestPermissions(activity, arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE), REQUEST_CODE_PERMISSIONS)
         }
     }
 


### PR DESCRIPTION
Removed READ_MEDIA_IMAGES and READ_MEDIA_VIDEO from manifest. On Android 13+, the system photo picker (ACTION_PICK) works without any permission. On Android <=12, still requests READ_EXTERNAL_STORAGE. This aligns with Google Play policy requiring a core use case for broad media access.