### PR TITLE
fix: add local.properties with baseUrl to CI workflow

### DIFF
--- a/.github/workflows/ktlint.yml
+++ b/.github/workflows/ktlint.yml
@@ -22,6 +22,10 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Create local.properties
+        run: |
+          echo "baseUrl=https://example.com" >> local.properties
+
       - name: Run ktlint format
         run: ./gradlew ktlintFormat
 


### PR DESCRIPTION
Add step to create local.properties with sdk.dir and baseUrl before running ktlint checks