### PR TITLE
Refactor: move fragment state into ViewModels

### DIFF
--- a/feature/explore/src/main/java/com/drs/auralife/feature/explore/explore_details/ExploreDetailContract.kt
+++ b/feature/explore/src/main/java/com/drs/auralife/feature/explore/explore_details/ExploreDetailContract.kt
@@ -3,6 +3,8 @@ package com.drs.auralife.feature.explore.explore_details
 import com.drs.auralife.domain.model.Film
 
 data class ExploreDetailUiState(
+    val slug: String = "",
+    val name: String = "",
     val films: List<Film> = emptyList(),
     val currentPage: Int = 1,
     val totalPages: Int = 0,

--- a/feature/explore/src/main/java/com/drs/auralife/feature/explore/explore_details/ExploreDetailFragment.kt
+++ b/feature/explore/src/main/java/com/drs/auralife/feature/explore/explore_details/ExploreDetailFragment.kt
@@ -24,8 +24,6 @@ class ExploreDetailFragment : Fragment() {
     private val exploreDetailViewModel: ExploreDetailViewModel by viewModels()
     private var _binding: FragmentExploreDetailsBinding? = null
     private val binding get() = _binding ?: error("Binding accessed after onDestroyView")
-    private var slug: String = ""
-    private var name: String = ""
 
     private val filmAdapter = ExploreDetailFilmAdapter { slug ->
         exploreDetailViewModel.onFilmClicked(slug)
@@ -41,14 +39,9 @@ class ExploreDetailFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        slug = requireArguments().getString("slug") ?: return
-        name = requireArguments().getString("name") ?: return
-
         binding.backButton.setOnClickListener {
             appNavigator.navigateBack()
         }
-
-        binding.tvCategoryName.text = name
 
         binding.recyclerView.apply {
             val displayMetrics = resources.displayMetrics
@@ -59,7 +52,7 @@ class ExploreDetailFragment : Fragment() {
 
         observeState()
         observeEffect()
-        exploreDetailViewModel.getFilmsByCategory(slug)
+        exploreDetailViewModel.getFilmsByCategory()
         setupPagination()
     }
 
@@ -71,6 +64,7 @@ class ExploreDetailFragment : Fragment() {
     private fun observeState() {
         launchAndRepeatWithViewLifecycle {
             exploreDetailViewModel.state.collect { state ->
+                binding.tvCategoryName.text = state.name
                 filmAdapter.submitList(state.films)
             }
         }
@@ -96,9 +90,9 @@ class ExploreDetailFragment : Fragment() {
         scrollListener = object : RecyclerView.OnScrollListener() {
             override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
                 val lastVisibleItemPosition = (recyclerView.layoutManager as GridLayoutManager).findLastVisibleItemPosition()
-                if (lastVisibleItemPosition >= filmAdapter.itemCount - 1) {
-                    exploreDetailViewModel.onScrolledToBottom(slug)
-                }
+                    if (lastVisibleItemPosition >= filmAdapter.itemCount - 1) {
+                        exploreDetailViewModel.onScrolledToBottom()
+                    }
             }
         }
         scrollListener?.let { binding.recyclerView.addOnScrollListener(it) }

--- a/feature/explore/src/main/java/com/drs/auralife/feature/explore/explore_details/ExploreDetailViewModel.kt
+++ b/feature/explore/src/main/java/com/drs/auralife/feature/explore/explore_details/ExploreDetailViewModel.kt
@@ -1,5 +1,6 @@
 ﻿package com.drs.auralife.feature.explore.explore_details
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.drs.auralife.domain.result.Result
@@ -12,53 +13,70 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class ExploreDetailViewModel @Inject constructor(
     private val getFilmsByCategoryUseCase: GetFilmsByCategoryUseCase,
+    savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
-    private val _state = MutableStateFlow(ExploreDetailUiState())
+    private val _state = MutableStateFlow(
+        ExploreDetailUiState(
+            slug = savedStateHandle.get<String>("slug") ?: "",
+            name = savedStateHandle.get<String>("name") ?: "",
+        ),
+    )
     val state: StateFlow<ExploreDetailUiState> = _state.asStateFlow()
 
     private val _effect = MutableSharedFlow<ExploreDetailUiEffect>()
     val effect: SharedFlow<ExploreDetailUiEffect> = _effect.asSharedFlow()
 
-    fun getFilmsByCategory(slug: String) {
+    fun getFilmsByCategory() {
+        val slug = _state.value.slug
         viewModelScope.launch {
-            _state.value = _state.value.copy(isLoading = true, currentPage = 1)
+            _state.update { it.copy(isLoading = true, currentPage = 1) }
             when (val result = getFilmsByCategoryUseCase(slug, 1)) {
                 is Result.Success -> {
                     val paged = result.data
-                    _state.value = ExploreDetailUiState(
-                        films = paged.data,
-                        totalPages = paged.totalPages,
-                        currentPage = 1,
-                    )
+                    _state.update {
+                        it.copy(
+                            films = paged.data,
+                            totalPages = paged.totalPages,
+                            currentPage = 1,
+                            isLoading = false,
+                        )
+                    }
                 }
 
-                is Result.Error -> _state.value = _state.value.copy(isLoading = false, errorMessage = result.errorMessage)
+                is Result.Error -> _state.update { it.copy(isLoading = false, errorMessage = result.errorMessage) }
                 is Result.Loading -> {}
             }
         }
     }
 
-    fun onScrolledToBottom(slug: String) {
+    fun onScrolledToBottom() {
         val current = _state.value
         if (current.isLoadingMore || current.currentPage >= current.totalPages) return
         val nextPage = current.currentPage + 1
         viewModelScope.launch {
-            _state.value = _state.value.copy(isLoadingMore = true)
-            when (val result = getFilmsByCategoryUseCase(slug, nextPage)) {
+            _state.update { it.copy(isLoadingMore = true) }
+            when (val result = getFilmsByCategoryUseCase(current.slug, nextPage)) {
                 is Result.Success -> {
                     val paged = result.data
-                    val appended = _state.value.films + paged.data
-                    _state.value = _state.value.copy(films = appended, totalPages = paged.totalPages, currentPage = nextPage, isLoadingMore = false)
+                    _state.update {
+                        it.copy(
+                            films = it.films + paged.data,
+                            totalPages = paged.totalPages,
+                            currentPage = nextPage,
+                            isLoadingMore = false,
+                        )
+                    }
                 }
 
-                is Result.Error -> _state.value = _state.value.copy(isLoadingMore = false, errorMessage = result.errorMessage)
+                is Result.Error -> _state.update { it.copy(isLoadingMore = false, errorMessage = result.errorMessage) }
                 is Result.Loading -> {}
             }
         }

--- a/feature/film-player/src/main/java/com/drs/auralife/feature/film_player/FilmPlayerContract.kt
+++ b/feature/film-player/src/main/java/com/drs/auralife/feature/film_player/FilmPlayerContract.kt
@@ -1,5 +1,12 @@
 package com.drs.auralife.feature.film_player
 
+data class FilmPlayerUiState(
+    val slug: String = "",
+    val currentEpisode: Int = 0,
+    val currentPosition: Long = 0,
+    val isFullscreen: Boolean = false,
+)
+
 sealed interface PlayFilmUiEffect {
     data object ShowPremiumDialog : PlayFilmUiEffect
     data class NavigateToPayment(val message: String) : PlayFilmUiEffect

--- a/feature/film-player/src/main/java/com/drs/auralife/feature/film_player/FilmPlayerFragment.kt
+++ b/feature/film-player/src/main/java/com/drs/auralife/feature/film_player/FilmPlayerFragment.kt
@@ -12,7 +12,9 @@ import android.widget.TextView
 import androidx.core.util.TypedValueCompat.dpToPx
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
@@ -23,13 +25,13 @@ import androidx.recyclerview.widget.RecyclerView
 import com.drs.auralife.core.navigation.AppNavigator
 import com.drs.auralife.designsystem.SystemUiController
 import com.drs.auralife.designsystem.launchAndRepeatWithViewLifecycle
-import com.drs.auralife.domain.model.FilmDetails
 import com.drs.auralife.feature.film.player.R
 import com.drs.auralife.feature.film_detail.FilmDetailsViewModel
 import com.drs.auralife.feature.film_player.adapter.EpisodeAdapter
 import com.drs.auralife.feature.history.HistoryViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import com.drs.auralife.core.designsystem.R as DsR
 
@@ -54,11 +56,6 @@ class FilmPlayerFragment : Fragment() {
     private var rotateButton: ImageButton? = null
 
     private var numberEpInLine = 3
-    private var currentEpisode = 0
-    private var currentPosition: Long = 0
-    private var isFullscreen = false
-    private var slug: String? = null
-    private var film: FilmDetails? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return inflater.inflate(R.layout.fragment_film_player, container, false)
@@ -66,8 +63,6 @@ class FilmPlayerFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        slug = requireArguments().getString("slug")
 
         exoPlayer = ExoPlayer.Builder(requireContext()).build()
         playerView = view.findViewById(R.id.player_view)
@@ -87,16 +82,15 @@ class FilmPlayerFragment : Fragment() {
         recyclerView?.layoutManager = GridLayoutManager(requireContext(), ++numberEpInLine)
 
         observeFilmDetails()
+        observeState()
         observeEffect()
 
-        slug?.let { s ->
-            viewLifecycleOwner.lifecycleScope.launch {
-                historyViewModel.getHistoryItem(s)?.let {
-                    currentEpisode = it.episode
-                    currentPosition = it.position
-                }
-                filmDetailsViewModel.getFilmDetails(s)
+        val slug = filmPlayerViewModel.slug
+        viewLifecycleOwner.lifecycleScope.launch {
+            historyViewModel.getHistoryItem(slug)?.let {
+                filmPlayerViewModel.restoreState(it.episode, it.position, false)
             }
+            filmDetailsViewModel.getFilmDetails(slug)
         }
 
         startPlaybackMonitor()
@@ -105,26 +99,28 @@ class FilmPlayerFragment : Fragment() {
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        outState.putInt("currentEpisode", currentEpisode)
-        outState.putBoolean("isFullscreen", isFullscreen)
+        val state = filmPlayerViewModel.state.value
+        outState.putInt("currentEpisode", state.currentEpisode)
+        outState.putBoolean("isFullscreen", state.isFullscreen)
         exoPlayer?.let { outState.putLong("exoPlayerPosition", it.currentPosition) }
     }
 
     override fun onViewStateRestored(savedInstanceState: Bundle?) {
         super.onViewStateRestored(savedInstanceState)
         if (savedInstanceState != null) {
-            isFullscreen = savedInstanceState.getBoolean("isFullscreen", false)
-            toggleFullscreen()
-            currentEpisode = savedInstanceState.getInt("currentEpisode", 0)
-            currentPosition = (savedInstanceState.getLong("exoPlayerPosition", 0) - 1000).coerceAtLeast(0)
-            playEpisode(currentEpisode)
+            val episode = savedInstanceState.getInt("currentEpisode", 0)
+            val position = (savedInstanceState.getLong("exoPlayerPosition", 0) - 1000).coerceAtLeast(0)
+            val fullscreen = savedInstanceState.getBoolean("isFullscreen", false)
+            filmPlayerViewModel.restoreState(episode, position, fullscreen)
+            playEpisode(episode)
         }
     }
 
     override fun onStop() {
         super.onStop()
+        val state = filmPlayerViewModel.state.value
         exoPlayer?.apply {
-            historyViewModel.addToHistory(slug.toString(), currentEpisode, currentPosition)
+            historyViewModel.addToHistory(state.slug, state.currentEpisode, state.currentPosition)
             pause()
             btnPlayPause?.isSelected = false
         }
@@ -132,7 +128,7 @@ class FilmPlayerFragment : Fragment() {
 
     override fun onPause() {
         super.onPause()
-        currentPosition = exoPlayer?.currentPosition ?: currentPosition
+        exoPlayer?.let { filmPlayerViewModel.setCurrentPosition(it.currentPosition) }
     }
 
     override fun onDestroyView() {
@@ -145,10 +141,10 @@ class FilmPlayerFragment : Fragment() {
         launchAndRepeatWithViewLifecycle {
             filmDetailsViewModel.state.collect { state ->
                 if (state.film != null) {
-                    film = state.film
-                    playEpisode(currentEpisode)
+                    val ep = filmPlayerViewModel.state.value.currentEpisode
+                    playEpisode(ep)
                     view?.findViewById<RecyclerView>(R.id.episodeRecyclerView)
-                        ?.adapter = EpisodeAdapter(state.film!!.episodes) { ep ->
+                        ?.adapter = EpisodeAdapter(state.film.episodes) { ep ->
                         playEpisode(ep)
                     }
                 }
@@ -156,6 +152,20 @@ class FilmPlayerFragment : Fragment() {
         }
 
         filmPlayerViewModel.loadPremiumStatus()
+    }
+
+    private fun observeState() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                filmPlayerViewModel.state.collect { state ->
+                    if (state.isFullscreen) {
+                        enterFullscreen()
+                    } else {
+                        exitFullscreen()
+                    }
+                }
+            }
+        }
     }
 
     private fun observeEffect() {
@@ -182,20 +192,21 @@ class FilmPlayerFragment : Fragment() {
     }
 
     private fun playEpisode(episodeIndex: Int) {
-        film?.let { filmDetails ->
-            if (episodeIndex in filmDetails.episodes.indices) {
-                val episode = filmDetails.episodes[episodeIndex]
-                exoPlayer?.setMediaItem(MediaItem.fromUri(episode.linkM3u8))
-                exoPlayer?.prepare()
-                exoPlayer?.seekTo(currentPosition)
-                exoPlayer?.play()
-                nameFilm?.text = episode.filename
-                if (currentEpisode != episodeIndex) {
-                    currentPosition = 0
-                }
-                currentEpisode = episodeIndex
-                btnPlayPause?.isSelected = true
+        val state = filmDetailsViewModel.state.value
+        val film = state.film ?: return
+        if (episodeIndex in film.episodes.indices) {
+            val episode = film.episodes[episodeIndex]
+            exoPlayer?.setMediaItem(MediaItem.fromUri(episode.linkM3u8))
+            exoPlayer?.prepare()
+            val playerState = filmPlayerViewModel.state.value
+            exoPlayer?.seekTo(playerState.currentPosition)
+            exoPlayer?.play()
+            nameFilm?.text = episode.filename
+            if (filmPlayerViewModel.state.value.currentEpisode != episodeIndex) {
+                filmPlayerViewModel.setCurrentPosition(0)
             }
+            filmPlayerViewModel.setCurrentEpisode(episodeIndex)
+            btnPlayPause?.isSelected = true
         }
     }
 
@@ -205,7 +216,7 @@ class FilmPlayerFragment : Fragment() {
                 object : Player.Listener {
                     override fun onPlaybackStateChanged(playbackState: Int) {
                         if (playbackState == Player.STATE_ENDED) {
-                            playEpisode(currentEpisode + 1)
+                            playEpisode(filmPlayerViewModel.state.value.currentEpisode + 1)
                         }
                     }
                 },
@@ -223,19 +234,18 @@ class FilmPlayerFragment : Fragment() {
             }
 
             btnRewind?.setOnClickListener {
-                val rewindPosition = currentPosition - 5000
+                val rewindPosition = filmPlayerViewModel.state.value.currentPosition - 5000
                 exoPlayer?.seekTo(rewindPosition.coerceAtLeast(0))
             }
             btnForward?.setOnClickListener {
-                val forwardPosition = currentPosition + 15000
+                val forwardPosition = filmPlayerViewModel.state.value.currentPosition + 15000
                 seekTo(forwardPosition.coerceAtMost(duration))
             }
-            btnPrevious?.setOnClickListener { playEpisode(currentEpisode - 1) }
-            btnNext?.setOnClickListener { playEpisode(currentEpisode + 1) }
+            btnPrevious?.setOnClickListener { playEpisode(filmPlayerViewModel.state.value.currentEpisode - 1) }
+            btnNext?.setOnClickListener { playEpisode(filmPlayerViewModel.state.value.currentEpisode + 1) }
 
             fullscreenButton?.setOnClickListener {
-                isFullscreen = !isFullscreen
-                toggleFullscreen()
+                filmPlayerViewModel.toggleFullscreen()
             }
 
             rotateButton?.setOnClickListener {
@@ -249,18 +259,27 @@ class FilmPlayerFragment : Fragment() {
     }
 
     private fun toggleFullscreen() {
+        val fullscreen = filmPlayerViewModel.state.value.isFullscreen
+        if (fullscreen) enterFullscreen() else exitFullscreen()
+    }
+
+    private fun enterFullscreen() {
         val recyclerView = view?.findViewById<RecyclerView>(R.id.episodeRecyclerView)
         val otherViews = listOf(recyclerView, nameFilm)
         playerView?.apply {
-            if (!isFullscreen) {
-                SystemUiController.showSystemUI(requireActivity().window)
-                otherViews.forEach { it?.visibility = View.VISIBLE }
-                layoutParams.height = dpToPx(250f, resources.displayMetrics).toInt()
-            } else {
-                SystemUiController.autoHideSystemUI(requireActivity().window)
-                otherViews.forEach { it?.visibility = View.GONE }
-                layoutParams.height = resources.displayMetrics.heightPixels
-            }
+            SystemUiController.autoHideSystemUI(requireActivity().window)
+            otherViews.forEach { it?.visibility = View.GONE }
+            layoutParams.height = resources.displayMetrics.heightPixels
+        }
+    }
+
+    private fun exitFullscreen() {
+        val recyclerView = view?.findViewById<RecyclerView>(R.id.episodeRecyclerView)
+        val otherViews = listOf(recyclerView, nameFilm)
+        playerView?.apply {
+            SystemUiController.showSystemUI(requireActivity().window)
+            otherViews.forEach { it?.visibility = View.VISIBLE }
+            layoutParams.height = dpToPx(250f, resources.displayMetrics).toInt()
         }
     }
 
@@ -298,4 +317,3 @@ class FilmPlayerFragment : Fragment() {
         dialog.show()
     }
 }
-

--- a/feature/film-player/src/main/java/com/drs/auralife/feature/film_player/FilmPlayerViewModel.kt
+++ b/feature/film-player/src/main/java/com/drs/auralife/feature/film_player/FilmPlayerViewModel.kt
@@ -1,5 +1,6 @@
 ﻿package com.drs.auralife.feature.film_player
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.drs.auralife.domain.repository.AuthRepository
@@ -12,6 +13,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -19,15 +21,35 @@ import javax.inject.Inject
 class FilmPlayerViewModel @Inject constructor(
     private val getPremiumStatusUseCase: GetPremiumStatusUseCase,
     private val authRepository: AuthRepository,
+    savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
-    fun isLoggedIn() = authRepository.isLoggedIn()
+    val slug: String = savedStateHandle.get<String>("slug") ?: ""
+
+    private val _state = MutableStateFlow(FilmPlayerUiState(slug = slug))
+    val state: StateFlow<FilmPlayerUiState> = _state.asStateFlow()
 
     private val _effect = MutableSharedFlow<PlayFilmUiEffect>(extraBufferCapacity = 1)
     val effect: SharedFlow<PlayFilmUiEffect> = _effect.asSharedFlow()
 
     private val _isPremium = MutableStateFlow(true)
     val isPremium: StateFlow<Boolean> = _isPremium.asStateFlow()
+
+    fun setCurrentEpisode(episode: Int) {
+        _state.update { it.copy(currentEpisode = episode) }
+    }
+
+    fun setCurrentPosition(position: Long) {
+        _state.update { it.copy(currentPosition = position) }
+    }
+
+    fun toggleFullscreen() {
+        _state.update { it.copy(isFullscreen = !it.isFullscreen) }
+    }
+
+    fun restoreState(episode: Int, position: Long, fullscreen: Boolean) {
+        _state.update { it.copy(currentEpisode = episode, currentPosition = position, isFullscreen = fullscreen) }
+    }
 
     fun loadPremiumStatus() {
         viewModelScope.launch {
@@ -54,4 +76,6 @@ class FilmPlayerViewModel @Inject constructor(
             }
         }
     }
+
+    private fun isLoggedIn() = authRepository.isLoggedIn()
 }

--- a/feature/library/src/main/java/com/drs/auralife/feature/library/library_details/LibraryDetailsContract.kt
+++ b/feature/library/src/main/java/com/drs/auralife/feature/library/library_details/LibraryDetailsContract.kt
@@ -3,6 +3,7 @@ package com.drs.auralife.feature.library.library_details
 import com.drs.auralife.domain.model.Film
 
 data class LibraryDetailUiState(
+    val name: String = "",
     val films: List<Film> = emptyList(),
     val isLoading: Boolean = false,
     val errorMessage: String? = null,

--- a/feature/library/src/main/java/com/drs/auralife/feature/library/library_details/LibraryDetailsFragment.kt
+++ b/feature/library/src/main/java/com/drs/auralife/feature/library/library_details/LibraryDetailsFragment.kt
@@ -1,9 +1,7 @@
 package com.drs.auralife.feature.library.library_details
 
-import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
@@ -24,7 +22,6 @@ class LibraryDetailsFragment : Fragment() {
     private val libraryDetailsViewModel: LibraryDetailsViewModel by viewModels()
     private var _binding: FragmentLibraryDetailsBinding? = null
     private val binding get() = _binding ?: error("Binding accessed after onDestroyView")
-    private var libraryName: String = ""
 
     private val filmAdapter = LibraryFilmAdapter(
         onItemClick = { slug -> libraryDetailsViewModel.onFilmClicked(slug) },
@@ -36,22 +33,18 @@ class LibraryDetailsFragment : Fragment() {
         return binding.root
     }
 
-    @SuppressLint("SetTextI18n")
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    override fun onViewCreated(view: android.view.View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         binding.recyclerView.adapter = filmAdapter
-        libraryName = requireArguments().getString("name") ?: return
 
         binding.backButton.setOnClickListener {
             appNavigator.navigateBack()
         }
 
-        binding.tvCategoryName.text = libraryName
-
         observeLibraryFilms()
         observeEffect()
-        libraryDetailsViewModel.loadLibraryFilms(libraryName)
+        libraryDetailsViewModel.loadLibraryFilms()
     }
 
     override fun onDestroyView() {
@@ -62,6 +55,7 @@ class LibraryDetailsFragment : Fragment() {
     private fun observeLibraryFilms() {
         launchAndRepeatWithViewLifecycle {
             libraryDetailsViewModel.state.collect { state ->
+                binding.tvCategoryName.text = state.name
                 if (state.films.isNotEmpty()) {
                     filmAdapter.submitList(state.films)
                 }
@@ -90,7 +84,7 @@ class LibraryDetailsFragment : Fragment() {
 
     private fun onLongClick(slug: String) {
         EditLibraryDialog.showDeleteFilmFromLibrary(requireContext()) {
-            libraryDetailsViewModel.removeFilm(libraryName, slug)
+            libraryDetailsViewModel.removeFilm(slug)
         }
     }
 }

--- a/feature/library/src/main/java/com/drs/auralife/feature/library/library_details/LibraryDetailsViewModel.kt
+++ b/feature/library/src/main/java/com/drs/auralife/feature/library/library_details/LibraryDetailsViewModel.kt
@@ -1,5 +1,6 @@
 ﻿package com.drs.auralife.feature.library.library_details
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.drs.auralife.domain.model.Film
@@ -17,6 +18,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -26,25 +28,29 @@ class LibraryDetailsViewModel @Inject constructor(
     private val getFilmDetailsUseCase: GetFilmDetailsUseCase,
     private val removeFilmFromLibraryUseCase: RemoveFilmFromLibraryUseCase,
     private val libraryRepository: LibraryRepository,
+    savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
-    private val _state = MutableStateFlow(LibraryDetailUiState())
+    private val _state = MutableStateFlow(
+        LibraryDetailUiState(name = savedStateHandle.get<String>("name") ?: ""),
+    )
     val state: StateFlow<LibraryDetailUiState> = _state.asStateFlow()
 
     private val _effect = MutableSharedFlow<LibraryDetailUiEffect>()
     val effect: SharedFlow<LibraryDetailUiEffect> = _effect.asSharedFlow()
 
-    fun loadLibraryFilms(name: String) {
+    fun loadLibraryFilms() {
         viewModelScope.launch {
-            _state.value = LibraryDetailUiState()
+            val name = _state.value.name
+            _state.update { LibraryDetailUiState(name = name) }
             when (val result = getLibraryUseCase()) {
                 is Result.Success -> {
                     val lib = result.data.find { it.name == name } ?: return@launch
                     val films = buildFilmsFromLibrary(lib)
-                    _state.value = LibraryDetailUiState(films = films)
+                    _state.update { it.copy(films = films) }
                 }
 
-                is Result.Error -> _state.value = LibraryDetailUiState(errorMessage = result.errorMessage)
+                is Result.Error -> _state.update { it.copy(errorMessage = result.errorMessage) }
                 is Result.Loading -> {}
             }
         }
@@ -76,9 +82,10 @@ class LibraryDetailsViewModel @Inject constructor(
         }
     }
 
-    fun removeFilm(libraryName: String, slug: String) {
+    fun removeFilm(slug: String) {
         viewModelScope.launch {
             try {
+                val libraryName = _state.value.name
                 removeFilmFromLibraryUseCase(libraryName, slug)
 
                 when (val result = getLibraryUseCase()) {
@@ -103,7 +110,7 @@ class LibraryDetailsViewModel @Inject constructor(
                     else -> {}
                 }
 
-                loadLibraryFilms(libraryName)
+                loadLibraryFilms()
                 _effect.emit(LibraryDetailUiEffect.ShowToast("Removed from library"))
             } catch (e: Exception) {
                 _effect.emit(LibraryDetailUiEffect.ShowToast(e.message ?: "Remove failed"))

--- a/feature/search/src/main/java/com/drs/auralife/feature/search/SearchFragment.kt
+++ b/feature/search/src/main/java/com/drs/auralife/feature/search/SearchFragment.kt
@@ -8,22 +8,13 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.drs.auralife.core.navigation.AppNavigator
 import com.drs.auralife.designsystem.launchAndRepeatWithViewLifecycle
 import com.drs.auralife.feature.search.databinding.FragmentSearchBinding
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.launch
 
-@OptIn(FlowPreview::class)
 @AndroidEntryPoint
 class SearchFragment : Fragment() {
 
@@ -33,7 +24,6 @@ class SearchFragment : Fragment() {
     private val binding get() = _binding ?: error("Binding accessed after onDestroyView")
 
     private val searchViewModel: SearchViewModel by viewModels()
-    private val searchQueryFlow = MutableStateFlow("")
     private var searchAdapter: SearchAdapter? = null
 
     override fun onCreateView(
@@ -68,11 +58,7 @@ class SearchFragment : Fragment() {
                 override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
                 override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
                 override fun afterTextChanged(s: Editable?) {
-                    searchQueryFlow.value = s.toString().trim()
-                    if (s.toString().trim().isEmpty()) {
-                        searchViewModel.clearResults()
-                        searchAdapter?.replaceItems(emptyList())
-                    }
+                    searchViewModel.setSearchQuery(s.toString().trim())
                 }
             },
         )
@@ -115,16 +101,6 @@ class SearchFragment : Fragment() {
                     }
                 }
             }
-        }
-
-        lifecycleScope.launch {
-            searchQueryFlow
-                .debounce(500)
-                .distinctUntilChanged()
-                .filter { it.isNotEmpty() }
-                .collectLatest { query ->
-                    searchViewModel.searchFilms(query, 5)
-                }
         }
     }
 }

--- a/feature/search/src/main/java/com/drs/auralife/feature/search/SearchViewModel.kt
+++ b/feature/search/src/main/java/com/drs/auralife/feature/search/SearchViewModel.kt
@@ -6,15 +6,21 @@ import com.drs.auralife.domain.result.Result
 import com.drs.auralife.domain.result.errorMessage
 import com.drs.auralife.domain.usecase.SearchFilmsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+@OptIn(FlowPreview::class)
 @HiltViewModel
 class SearchViewModel @Inject constructor(
     private val searchFilmsUseCase: SearchFilmsUseCase,
@@ -25,6 +31,28 @@ class SearchViewModel @Inject constructor(
 
     private val _effect = MutableSharedFlow<SearchUiEffect>(extraBufferCapacity = 1)
     val effect: SharedFlow<SearchUiEffect> = _effect.asSharedFlow()
+
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            _searchQuery
+                .debounce(500)
+                .distinctUntilChanged()
+                .filter { it.isNotEmpty() }
+                .collectLatest { query ->
+                    searchFilms(query, 5)
+                }
+        }
+    }
+
+    fun setSearchQuery(query: String) {
+        _searchQuery.value = query
+        if (query.isEmpty()) {
+            clearResults()
+        }
+    }
 
     fun searchFilms(keyword: String, limit: Int) {
         if (keyword.isBlank()) {
@@ -49,4 +77,3 @@ class SearchViewModel @Inject constructor(
         _effect.tryEmit(SearchUiEffect.NavigateToFilmDetails(slug))
     }
 }
-


### PR DESCRIPTION
Move mutable state from 4 Fragments into their respective ViewModels

**FilmPlayerFragment** (5 vars):
- currentEpisode, currentPosition, isFullscreen, slug, film -> FilmPlayerUiState
- Uses SavedStateHandle to auto-restore on config change

**ExploreDetailFragment** (2 vars):
- slug, name -> ExploreDetailUiState via SavedStateHandle

**LibraryDetailsFragment** (1 var):
- libraryName -> LibraryDetailUiState via SavedStateHandle

**SearchFragment** (1 var):
- searchQueryFlow + debounce logic -> SearchViewModel